### PR TITLE
feat: provide plugin handling

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -408,4 +408,18 @@ return [
             'users',
         ],
     ],
+
+    /**
+     * Additional plugins to load with this format: 'PluginName' => load options array
+     * Where options array may contain
+     *
+     * - `debugOnly` - boolean - (default: false) Whether or not you want to load the plugin when in 'debug' mode only
+     * - `bootstrap` - boolean - (default: false) Whether or not you want the $plugin/config/bootstrap.php file loaded.
+     * - `routes` - boolean - (default: false) Whether or not you want to load the $plugin/config/routes.php file.
+     * - `ignoreMissing` - boolean - (default: false) Set to true to ignore missing bootstrap/routes files.
+     * - `autoload` - boolean - (default: false) Whether or not you want an autoloader registered
+     */
+    'Plugins' => [
+        'Dogs' => ['autoload' => true, 'bootstrap' => true, 'routes' => true], // a simple Dogs plugin
+    ],
 ];

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -419,7 +419,7 @@ return [
      * - `ignoreMissing` - boolean - (default: false) Set to true to ignore missing bootstrap/routes files.
      * - `autoload` - boolean - (default: false) Whether or not you want an autoloader registered
      */
-    'Plugins' => [
-        'Dogs' => ['autoload' => true, 'bootstrap' => true, 'routes' => true], // a simple Dogs plugin
-    ],
+    //'Plugins' => [
+    //    'MyPlugin' => ['autoload' => true, 'bootstrap' => true, 'routes' => true], // a simple plugin
+    //],
 ];

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -29,12 +29,12 @@ require __DIR__ . '/paths.php';
  */
 require CORE_PATH . 'config' . DS . 'bootstrap.php';
 
+use App\Plugin;
 use Cake\Cache\Cache;
 use Cake\Console\ConsoleErrorHandler;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
-use Cake\Core\Plugin;
 use Cake\Database\Type;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\ErrorHandler;
@@ -222,3 +222,8 @@ Plugin::load('WyriHaximus/TwigView', [
 if (Configure::read('debug')) {
     Plugin::load('DebugKit', ['bootstrap' => true]);
 }
+
+/*
+ * Load other custom / 3rd party plugins via configuration key 'Plugins'.
+ */
+Plugin::loadFromConfig();

--- a/config/routes.php
+++ b/config/routes.php
@@ -43,6 +43,12 @@ use Cake\Routing\Route\DashedRoute;
  */
 Router::defaultRouteClass(DashedRoute::class);
 
+/**
+ * Load all plugin routes. See the Plugin documentation on
+ * how to customize the loading of plugin routes.
+ */
+Plugin::routes();
+
 Router::scope('/', function (RouteBuilder $routes) {
 
     // Login.
@@ -115,9 +121,3 @@ Router::scope('/', function (RouteBuilder $routes) {
 
     $routes->fallbacks(DashedRoute::class);
 });
-
-/**
- * Load all plugin routes. See the Plugin documentation on
- * how to customize the loading of plugin routes.
- */
-Plugin::routes();

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -119,6 +119,10 @@ class ModulesComponent extends Component
                 return -$idx;
             })
             ->toList();
+        $plugins = Configure::read('Modules.plugins');
+        if ($plugins) {
+            $modules = array_merge($modules, $plugins);
+        }
 
         return $modules;
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App;
+
+use Cake\Core\Configure;
+use Cake\Core\Plugin as CakePlugin;
+
+/**
+ * {@inheritDoc}
+ *
+ * Extended with BEdita plugins utilities
+ */
+class Plugin extends CakePlugin
+{
+
+    /**
+     * Plugins load defaults
+     *
+     * @return void
+     */
+    protected static $_defaults = [
+        'debugOnly' => false,
+        'autoload' => false,
+        'bootstrap' => false,
+        'routes' => false,
+        'ignoreMissing' => false
+    ];
+
+    /**
+     * Load plugins from 'Plugins' configuration
+     *
+     * @return void
+     */
+    public static function loadFromConfig()
+    {
+        $plugins = Configure::read('Plugins');
+        if ($plugins) {
+            foreach ($plugins as $plugin => $options) {
+                $options = array_merge(static::$_defaults, $options);
+                if (!$options['debugOnly'] || ($options['debugOnly'] && Configure::read('debug'))) {
+                    static::load($plugin, $options);
+                }
+            }
+        }
+    }
+}

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -243,7 +243,7 @@ class ModulesComponentTest extends TestCase
                     'supporto',
                 ],
                 [
-                    'resources' => [
+                    [
                         'name' => 'plugin',
                     ],
                 ],

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -211,6 +211,7 @@ class ModulesComponentTest extends TestCase
                     'supporto',
                     'gustavo',
                     'trash',
+                    'plugin',
                 ],
                 [
                     'resources' => [
@@ -240,6 +241,11 @@ class ModulesComponentTest extends TestCase
                 [
                     'bedita',
                     'supporto',
+                ],
+                [
+                    'resources' => [
+                        'name' => 'plugin',
+                    ],
                 ],
             ],
             'ok (trash first)' => [
@@ -302,9 +308,10 @@ class ModulesComponentTest extends TestCase
      * @covers ::getMeta()
      * @covers ::getModules()
      */
-    public function testGetModules($expected, $meta, array $order = [])
+    public function testGetModules($expected, $meta, array $order = [], array $plugins = [])
     {
         Configure::write('Modules.order', $order);
+        Configure::write('Modules.plugins', $plugins);
 
         if ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Test\TestCase;
+
+use App\Plugin;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+
+/**
+ * \App\Plugin Test Case
+ *
+ * @coversDefaultClass \App\Plugin
+ */
+class PluginTest extends TestCase
+{
+
+    /**
+     * Test load from config method
+     *
+     * @return void
+     *
+     * @covers ::loadFromConfig()
+     */
+    public function testLoadConfig()
+    {
+        $debug = Configure::read('debug');
+        $pluginsConfig = [
+            'DebugKit' => ['debugOnly' => true],
+            'Migrations' => ['debugOnly' => false],
+        ];
+        Plugin::unload('DebugKit');
+        Plugin::unload('Migrations');
+        Configure::write('debug', 1);
+        Configure::write('Plugins', $pluginsConfig);
+        Plugin::loadFromConfig();
+        $this->assertTrue(Plugin::loaded('DebugKit'));
+        $this->assertTrue(Plugin::loaded('Migrations'));
+
+        Plugin::unload('DebugKit');
+        Plugin::unload('Migrations');
+        Configure::write('debug', 0);
+        Plugin::loadFromConfig();
+        $this->assertFalse(Plugin::loaded('DebugKit'));
+        $this->assertTrue(Plugin::loaded('Migrations'));
+
+        Configure::write('debug', $debug);
+    }
+}


### PR DESCRIPTION
This provides cakephp plugin handle.
Example use (for a module plugin):

- create a plugin `dogs` in `plugins`
- load plugin in bedita4web `config/app.php`:
```
    'Plugins' => [
        'Dogs' => ['autoload' => true, 'bootstrap' => true, 'routes' => true],
    ],
```
In `plugins/Dogs/config/bootstrap.php`:
```
use Cake\Core\Configure;

Configure::write('Modules.plugins', (array)Configure::read('Modules.plugins') + [['name' => 'dogs']]);
```
In `plugins/Dogs/config/routes.php`:
```
use Cake\Routing\RouteBuilder;
use Cake\Routing\Router;

Router::plugin(
    'Dogs',
    ['path' => '/'],
    function (RouteBuilder $routes) {
        $routes->connect(
            '/dogs',
            ['controller' => 'Dogs', 'action' => 'index']
        );
        $routes->connect(
            '/dogs/view/:id',
            ['controller' => 'Dogs', 'action' => 'view'],
            ['pass' => ['id']]
        );
        $routes->connect(
            '/dogs/create',
            ['controller' => 'Dogs', 'action' => 'update']
        );
    }
);
```
- enjoy