### PR TITLE
API tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !/logs/.gitkeep
 /phpunit.xml
 /provision/*
+/tests/.env
 /tmp/*
 !/tmp/.gitkeep
 /vendor/*
@@ -35,6 +36,7 @@
 ######################
 .DS_Store
 .DS_Store?
+.directory
 ._*
 .Spotlight-V100
 .Trashes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,24 @@
-sudo: false
+sudo: required
+
+services:
+  - docker
 
 language: php
+
+env:
+  global:
+    - BEDITA_API_KEY=12345
+    - BEDITA_API=http://127.0.0.1:8080
+    - BEDITA_ADMIN_USR=admin
+    - BEDITA_ADMIN_PWD=admin
 
 before_install:
   # Use GitHub OAuth token with Composer to increase API limits.
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi
+  - docker pull bedita/bedita:4-cactus
+  - docker run -d -p 127.0.0.1:8080:80 --env BEDITA_API_KEY=${BEDITA_API_KEY} --env BEDITA_ADMIN_USR=${BEDITA_ADMIN_USR} --env BEDITA_ADMIN_PWD=${BEDITA_ADMIN_PWD} bedita/bedita:4-cactus
+  - sleep 10
+  - docker ps -a
 
 install:
   # Install Composer dependencies.
@@ -26,6 +40,7 @@ jobs:
     - php: 7.2
     - php: 7.2
       env: "RUN=phpcs"
+      before_install: skip
       script: |
         vendor/bin/phpcs -n -p --extensions=php \
           --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=/Migrations/,/Seeds/ \

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ node_modules/.bin/gulp dev --host http://bedita4web.lcl
 
 ```
 
+### Run tests
+
+To setup tests locally simply copy tests/.env.default to tests/.env and set env vars accordingly
+To launch tests:
+
+```bash
+
+vendors/bin/phpunit [test folder or file, default '/tests']
+
+```
+
 ## Licensing
 
 BEdita is released under [LGPL](/bedita/bedita/blob/master/LICENSE.LGPL), Lesser General Public License v3.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,7 +34,10 @@
     <filter>
         <whitelist>
             <directory suffix=".php">./src/</directory>
-            <directory suffix=".php">./plugins/*/src/</directory>
+            <exclude>
+                <file>./src/Console/Installer.php</file>
+                <file>./src/Shell/ConsoleShell.php</file>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/.env.default
+++ b/tests/.env.default
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Used as a default to seed `tests/.env` which
+# enables you to use environment variables to configure
+# the test environment.
+#
+# To use this file, first copy it into `tests/.env`.
+
+# Uncomment these to define BEDITA API base URL and API KEY
+export BEDITA_API="https://bedita-api-url"
+export BEDITA_API_KEY="bedita-api-key"
+
+# Set admin credentials
+export BEDITA_ADMIN_USR="admin"
+export BEDITA_ADMIN_PWD="admin"

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\Controller;
+
+use App\Controller\LoginController;
+use BEdita\SDK\BEditaClient;
+use BEdita\SDK\BEditaClientException;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Controller\LoginController} Test Case
+ *
+ * @coversDefaultClass \App\Controller\LoginController
+ */
+class LoginControllerTest extends TestCase
+{
+
+    /**
+     * Test subject
+     *
+     * @var \App\Controller\LoginController
+     */
+    public $Login;
+
+    /**
+     * Test request config
+     *
+     * @var array
+     */
+    public $defaultRequestConfig = [
+        'environment' => [
+            'REQUEST_METHOD' => 'POST',
+        ],
+        'post' => [
+            'username' => '',
+            'password' => '',
+        ],
+    ];
+
+    /**
+     * Setup controller to test with request config
+     *
+     * @param array $requestConfig
+     * @return void
+     */
+    protected function setupController(array $requestConfig): void
+    {
+        $config = array_merge($this->defaultRequestConfig, $requestConfig);
+        $request = new ServerRequest($config);
+        $this->Login = new LoginController($request);
+    }
+
+    /**
+     * Test `login` method
+     *
+     * @covers ::login()
+     *
+     * @return void
+     */
+    public function testLogin()
+    {
+        $this->setupController([
+            'post' => [
+                'username' => env('BEDITA_ADMIN_USR'),
+                'password' => env('BEDITA_ADMIN_PWD'),
+            ]
+        ]);
+
+        $response = $this->Login->login();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('/', $response->getHeaderLine('Location'));
+    }
+
+    /**
+     * Test `login` fail method
+     *
+     * @covers ::login()
+     *
+     * @return void
+     */
+    public function testLoginFailed()
+    {
+        $this->setupController([
+            'post' => [
+                'username' => 'wronguser',
+                'password' => 'wrongpwd',
+            ]
+        ]);
+
+        $response = $this->Login->login();
+        static::assertNull($response);
+    }
+
+    /**
+     * Test `login` method with GET
+     *
+     * @covers ::login()
+     *
+     * @return void
+     */
+    public function testLoginForm()
+    {
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+        ]);
+
+        $response = $this->Login->login();
+        static::assertNull($response);
+    }
+
+    /**
+     * Test `logout` method
+     *
+     * @covers ::logout()
+     *
+     * @return void
+     */
+    public function testLogout()
+    {
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+        ]);
+
+        $response = $this->Login->logout();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('/login', $response->getHeaderLine('Location'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,12 +6,24 @@
  * unit tests in this file.
  */
 
-use Cake\Cache\Cache;
+/**
+ * Load test env vars from tests/.env file if not already set by environment
+ */
+if (!getenv('BEDITA_API') && file_exists(dirname(__DIR__) . '/tests/.env')) {
+    $dotenv = new \josegonzalez\Dotenv\Loader([dirname(__DIR__) . '/tests/.env']);
+    $dotenv->parse()
+        ->putenv()
+        ->toEnv()
+        ->toServer();
+}
+
+// set `APP_NAME` env to avoid config/.env load
+putenv('APP_NAME=TESTAPP');
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 require dirname(__DIR__) . '/config/bootstrap.php';
 
-Cache::disable();
+\Cake\Cache\Cache::disable();
 
 $_SERVER['PHP_SELF'] = '/';


### PR DESCRIPTION
This PR introduces testing against BE4 API

To setup tests locally simply copy `tests/.env.default` to `tests/.env` and set env vars accordingly

* first `Controller` test on `LoginController` was created, others will follow
* travis CI uses now the official BE4 docker image
