### PR TITLE
#34 feat: users form fields order

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -426,6 +426,7 @@ return [
             'core_attributes' => [
                 'username',
                 'password',
+                'confirm-password',
                 'name',
                 'surname',
                 'email',

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -420,7 +420,17 @@ return [
             'profiles' => '#093',
             'users' => '#555',
             'videos' => '#f03',
-        ]
+        ],
+
+        'users' => [
+            'core_attributes' => [
+                'username',
+                'password',
+                'name',
+                'surname',
+                'email',
+            ],
+        ],
     ],
 
     /**

--- a/src/Template/Element/Form/core_properties.twig
+++ b/src/Template/Element/Form/core_properties.twig
@@ -1,18 +1,45 @@
 {% set attributes = data.attributes %}
+{% set module = currentModule.name|default('') %}
+{% set core_properties = config('Modules.' ~ module ~ '.core_attributes')|default(['title', 'description', 'uname', 'status']) %}
 
 <div class="tab"><h2>{{ __('Main Properties') }}</h2></div>
 
 <fieldset id="core_properties">
     {{ Form.hidden('id', {'value': object.id})|raw }}
-    {{ Form.control('title')|raw }}
-    {{ Form.control('description', {'type': 'textarea'})|raw }}
-    {{ Form.control('uname')|raw }}
-    {{ Form.control('status', {
-        'type': 'radio',
-        'options': [
-            {'value': 'on', 'text': __('On')},
-            {'value': 'draft', 'text': __('Draft')},
-            {'value': 'off', 'text': __('Off')},
-        ]
-    })|raw }}
+
+
+{% for key, property in core_properties %}
+    {% if property == 'password' %}
+    <div class="password-component">
+        {{ Form.control('password', {
+            'class': 'password',
+            'placeholder': 'new password',
+            'autocomplete': 'new-password',
+            'default': ''
+        })|raw }}
+        {{ Form.control('password', {
+            'label': 'Retype password',
+            'id': 'confirm_password',
+            'name': 'confirm-password',
+            'class': 'confirm-password',
+            'placeholder': 'confirm password',
+            'autocomplete': 'new-password',
+            'default': ''
+        })|raw }}
+    </div>
+    {% elseif property == 'description' %}
+        {{ Form.control('description', {'type': 'textarea'})|raw }}
+    {% elseif property == 'status' %}
+        {{ Form.control('status', {
+            'type': 'radio',
+            'options': [
+                {'value': 'on', 'text': __('On')},
+                {'value': 'draft', 'text': __('Draft')},
+                {'value': 'off', 'text': __('Off')},
+            ]
+        })|raw }}
+    {% else %}
+        {{ Form.control(property, {'type': Schema.getControlTypeFromSchema(property)})|raw }}
+    {% endif %}
+{% endfor %}
 </fieldset>

--- a/src/Template/Element/Form/core_properties.twig
+++ b/src/Template/Element/Form/core_properties.twig
@@ -1,45 +1,16 @@
+{% set default_core_attributes = ['title', 'description', 'uname', 'status'] %}
 {% set attributes = data.attributes %}
 {% set module = currentModule.name|default('') %}
-{% set core_properties = config('Modules.' ~ module ~ '.core_attributes')|default(['title', 'description', 'uname', 'status']) %}
+{% set core_properties = config('Modules.' ~ module ~ '.core_attributes')|default(default_core_attributes) %}
 
 <div class="tab"><h2>{{ __('Main Properties') }}</h2></div>
 
 <fieldset id="core_properties">
     {{ Form.hidden('id', {'value': object.id})|raw }}
 
-
-{% for key, property in core_properties %}
-    {% if property == 'password' %}
-    <div class="password-component">
-        {{ Form.control('password', {
-            'class': 'password',
-            'placeholder': 'new password',
-            'autocomplete': 'new-password',
-            'default': ''
-        })|raw }}
-        {{ Form.control('password', {
-            'label': 'Retype password',
-            'id': 'confirm_password',
-            'name': 'confirm-password',
-            'class': 'confirm-password',
-            'placeholder': 'confirm password',
-            'autocomplete': 'new-password',
-            'default': ''
-        })|raw }}
-    </div>
-    {% elseif property == 'description' %}
-        {{ Form.control('description', {'type': 'textarea'})|raw }}
-    {% elseif property == 'status' %}
-        {{ Form.control('status', {
-            'type': 'radio',
-            'options': [
-                {'value': 'on', 'text': __('On')},
-                {'value': 'draft', 'text': __('Draft')},
-                {'value': 'off', 'text': __('Off')},
-            ]
-        })|raw }}
-    {% else %}
-        {{ Form.control(property, {'type': Schema.getControlTypeFromSchema(property)})|raw }}
-    {% endif %}
+{% for key, fieldName in core_properties %}
+    {% set type = Schema.getControlTypeFromSchema(fieldName) %}
+    {% set options = Schema.getControlOptionFromTypeAndName(type, fieldName) %}
+    {{ Form.control(fieldName, options)|raw }}
 {% endfor %}
 </fieldset>

--- a/src/Template/Element/Form/core_properties.twig
+++ b/src/Template/Element/Form/core_properties.twig
@@ -10,7 +10,7 @@
 
 {% for key, fieldName in core_properties %}
     {% set type = Schema.getControlTypeFromSchema(fieldName) %}
-    {% set options = Schema.getControlOptionFromTypeAndName(type, fieldName) %}
+    {% set options = Schema.getControlOptionFromTypeAndName(type, fieldName, attributes.fieldName) %}
     {{ Form.control(fieldName, options)|raw }}
 {% endfor %}
 </fieldset>

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -10,15 +10,12 @@
 
 <fieldset id="object_properties">
 {% set jsonKeys = [] %}
-{% for key, value in other_properties %}
-    {% set property = schema.properties[key] %}
-    {% set type = Schema.getTypeFromSchema(property) %}
-    {% if type == 'json' %}
-        {% set jsonKeys = jsonKeys|merge([key]) %}
-        {{ Form.control(key, {'type': 'textarea', 'class': 'json', 'value': value|json_encode})|raw }}
-    {% else %}
-        {{ Form.control(key, {'type': Schema.getControlTypeFromSchema(property)})|raw }}
-    {% endif %}
+{% for fieldName, value in other_properties %}
+    {% set property = schema.properties[fieldName] %}
+    {% set ptype = Schema.getTypeFromSchema(property) %}
+    {% set type = (ptype == 'json') ? 'json' : Schema.getControlTypeFromSchema(fieldName, ptype) %}
+    {% set options = Schema.getControlOptionFromTypeAndName(type, fieldName, value) %}
+    {{ Form.control(fieldName, options)|raw }}
 {% endfor %}
 {% if jsonKeys %}
     {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': jsonKeys|join(',')})|raw }}

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -1,47 +1,24 @@
 {% element 'Form/_other_properties_script' %}
+{% set all_attributes = object.attributes|default([]) %}
+{% set module = currentModule.name|default('') %}
+{% set core_properties = config('Modules.' ~ module ~ '.core_attributes')|default(['title', 'description', 'uname', 'status']) %}
+{% set other_properties = Array.removeKeys(all_attributes, core_properties) %}
 
 <div class="tab"><h2>{{ __('Other Properties') }}</h2></div>
 
 <fieldset id="object_properties">
-
 {% set jsonKeys = [] %}
-{% for key, value in object.attributes %}
-    {% if not in_array(key, ['title', 'description', 'uname', 'status']) %}
-        {% set property = schema.properties[key] %}
-        {% set type = Schema.getTypeFromSchema(property) %}
-        {% if type == 'json' %}
-            {% set jsonKeys = jsonKeys|merge([key]) %}
-            {{ Form.control(key, {'type': 'textarea', 'class': 'json', 'value': value|json_encode})|raw }}
-        {% else %}
-            {{ Form.control(key, {'type': Schema.getControlTypeFromSchema(property)})|raw }}
-
-            {% if key == 'username' and currentModule.name == 'users' %}
-                <div class="password-component">
-                    {{ Form.control('password', {
-                        'class': 'password',
-                        'placeholder': 'new password',
-                        'autocomplete': 'new-password',
-                        'default': ''
-                    })|raw }}
-
-                    {{ Form.control('password', {
-                        'label': 'Retype password',
-                        'id': 'confirm_password',
-                        'name': 'confirm-password',
-                        'class': 'confirm-password',
-                        'placeholder': 'confirm password',
-                        'autocomplete': 'new-password',
-                        'default': ''
-                    })|raw }}
-                </div>
-            {% endif %}
-
-        {% endif %}
+{% for key, value in other_properties %}
+    {% set property = schema.properties[key] %}
+    {% set type = Schema.getTypeFromSchema(property) %}
+    {% if type == 'json' %}
+        {% set jsonKeys = jsonKeys|merge([key]) %}
+        {{ Form.control(key, {'type': 'textarea', 'class': 'json', 'value': value|json_encode})|raw }}
+    {% else %}
+        {{ Form.control(key, {'type': Schema.getControlTypeFromSchema(property)})|raw }}
     {% endif %}
 {% endfor %}
 {% if jsonKeys %}
     {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': jsonKeys|join(',')})|raw }}
 {% endif %}
-
-
 </fieldset>

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -1,7 +1,9 @@
 {% element 'Form/_other_properties_script' %}
+
+{% set default_core_attributes = ['title', 'description', 'uname', 'status'] %}
 {% set all_attributes = object.attributes|default([]) %}
 {% set module = currentModule.name|default('') %}
-{% set core_properties = config('Modules.' ~ module ~ '.core_attributes')|default(['title', 'description', 'uname', 'status']) %}
+{% set core_properties = config('Modules.' ~ module ~ '.core_attributes')|default(default_core_attributes) %}
 {% set other_properties = Array.removeKeys(all_attributes, core_properties) %}
 
 <div class="tab"><h2>{{ __('Other Properties') }}</h2></div>

--- a/src/View/Helper/ArrayHelper.php
+++ b/src/View/Helper/ArrayHelper.php
@@ -25,7 +25,6 @@ class ArrayHelper extends Helper
      * Return array_combine of array using values as keys.
      *
      * @param array $arr The array.
-     *
      * @return array combined array.
      */
     public function combine(array $arr) : array
@@ -36,9 +35,8 @@ class ArrayHelper extends Helper
     /**
      * Return array without specified keys.
      *
-     * @param array $arr  The array.
+     * @param array $arr The array.
      * @param array $keys The keys to remove.
-     *
      * @return array The array without keys.
      */
     public function removeKeys(array $arr, array $keys) : array

--- a/src/View/Helper/ArrayHelper.php
+++ b/src/View/Helper/ArrayHelper.php
@@ -25,10 +25,31 @@ class ArrayHelper extends Helper
      * Return array_combine of array using values as keys.
      *
      * @param array $arr The array.
+     *
      * @return array combined array.
      */
     public function combine(array $arr) : array
     {
         return array_combine(array_values($arr), array_values($arr));
+    }
+
+    /**
+     * Return array without specified keys.
+     *
+     * @param array $arr  The array.
+     * @param array $keys The keys to remove.
+     *
+     * @return array The array without keys.
+     */
+    public function removeKeys(array $arr, array $keys) : array
+    {
+        $result = [];
+        foreach ($arr as $k => $v) {
+            if (!in_array($k, $keys)) {
+                $result[$k] = $v;
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/View/Helper/ArrayHelper.php
+++ b/src/View/Helper/ArrayHelper.php
@@ -41,13 +41,6 @@ class ArrayHelper extends Helper
      */
     public function removeKeys(array $arr, array $keys) : array
     {
-        $result = [];
-        foreach ($arr as $k => $v) {
-            if (!in_array($k, $keys)) {
-                $result[$k] = $v;
-            }
-        }
-
-        return $result;
+        return array_diff_key($arr, array_flip($keys));
     }
 }

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -101,4 +101,47 @@ class SchemaHelper extends Helper
 
         return $schema['type'];
     }
+
+    /**
+     * Get control option object for field type and name
+     *
+     * @param string $type The type (i.e. 'radio', 'text', 'textarea', etc.)
+     * @param string $name The field name.
+     * @return array
+     */
+    public function getControlOptionFromTypeAndName($type, $name) : array
+    {
+        if ($name === 'status') {
+            return [
+                'type' => 'radio',
+                'options' => [
+                    ['value' => 'on', 'text' => __('On')],
+                    ['value' => 'draft', 'text' => __('Draft')],
+                    ['value' => 'off', 'text' => __('Off')],
+                ],
+            ];
+        }
+        if ($name === 'password') {
+            return [
+                'class' => 'password',
+                'placeholder' => __('new password'),
+                'autocomplete' => 'new-password',
+                'default' => '',
+            ];
+        }
+        if ($name === 'confirm-password') {
+            return [
+                'label' => __('Retype password'),
+                'id' => 'confirm_password',
+                'name' => 'confirm-password',
+                'class' => 'confirm-password',
+                'placeholder' => __('confirm password'),
+                'autocomplete' => 'new-password',
+                'default' => '',
+                'type' => 'password',
+            ];
+        }
+
+        return compact('type');
+    }
 }

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -103,13 +103,14 @@ class SchemaHelper extends Helper
     }
 
     /**
-     * Get control option object for field type and name
+     * Get control option object for field type, name and value.
      *
-     * @param string $type The type (i.e. 'radio', 'text', 'textarea', etc.)
+     * @param string $type The type (i.e. 'radio', 'text', 'textarea', 'json', etc.)
      * @param string $name The field name.
+     * @param string $value The field value.
      * @return array
      */
-    public function getControlOptionFromTypeAndName($type, $name) : array
+    public function getControlOptionFromTypeAndName($type, $name, $value) : array
     {
         if ($name === 'status') {
             return [
@@ -139,6 +140,13 @@ class SchemaHelper extends Helper
                 'autocomplete' => 'new-password',
                 'default' => '',
                 'type' => 'password',
+            ];
+        }
+        if ($type === 'json') {
+            return [
+                'type' => 'textarea',
+                'class' => 'json',
+                'value' => json_encode($value),
             ];
         }
 

--- a/tests/TestCase/View/Helper/ArrayHelperTest.php
+++ b/tests/TestCase/View/Helper/ArrayHelperTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\ArrayHelper;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+/**
+ * {@see \App\View\Helper\ArrayHelper} Test Case
+ *
+ * @coversDefaultClass \App\View\Helper\ArrayHelper
+ */
+class ArrayHelperTest extends TestCase
+{
+
+    /**
+     * Test subject
+     *
+     * @var \App\View\Helper\ArrayHelper
+     */
+    public $Array;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $view = new View();
+        $this->Array = new ArrayHelper($view);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown() : void
+    {
+        unset($this->Array);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Data provider for `testCombine` test case.
+     *
+     * @return array
+     */
+    public function getCombineSchemaProvider() : array
+    {
+        $arr = [10, 20, 50, 100];
+
+        return [
+            'combine arrays' => [
+                [
+                    10 => 10,
+                    20 => 20,
+                    50 => 50,
+                    100 => 100,
+                ],
+                [10, 20, 50, 100],
+            ],
+        ];
+    }
+
+    /**
+     * Test `combine()` method.
+     *
+     * @dataProvider getCombineSchemaProvider()
+     * @covers ::combine()
+     * @param array $expected The expected array.
+     * @param array $arr The array.
+     * @return void
+     */
+    public function testCombine(array $expected, array $arr)
+    {
+        $actual = $this->Array->combine($arr);
+
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testRemoveKeys` test case.
+     *
+     * @return array
+     */
+    public function getRemoveKeysSchemaProvider() : array
+    {
+        return [
+            'basic data' => [
+                [
+                    'title' => 'string',
+                    'description' => 'string',
+                    'uname' => 'string',
+                    'status' => 'string'
+                ], // expected
+                [
+                    'title' => 'string',
+                    'description' => 'string',
+                    'uname' => 'string',
+                    'status' => 'string',
+                    'extra' => 'object',
+                ], // data
+                [
+                    'extra'
+                ], // keys to remove
+            ]
+        ];
+    }
+
+    /**
+     * Test `removeKeys()` method.
+     *
+     * @dataProvider getRemoveKeysSchemaProvider()
+     * @covers ::removeKeys()
+     * @param array $expected The expected array.
+     * @param array $arr The array.
+     * @param array $keys The keys to remove.
+     * @return void
+     */
+    public function testRemoveKeys(array $expected, array $arr, array $keys)
+    {
+        $actual = $this->Array->removeKeys($arr, $keys);
+
+        static::assertSame($expected, $actual);
+    }
+}

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -142,4 +142,91 @@ class SchemaHelperTest extends TestCase
 
         static::assertSame($expected, $actual);
     }
+
+    /**
+     * Data provider for `testGetControlOptionFromTypeAndName` test case.
+     *
+     * @return array
+     */
+    public function getControlOptionFromTypeAndNameSchemaProvider() : array
+    {
+        return [
+            'text' => [
+                // expected result
+                [
+                    'type' => 'text',
+                ],
+                // params (type, name, value)
+                'text', 'test', '',
+            ],
+            'status' => [
+                // expected result
+                [
+                    'type' => 'radio',
+                    'options' => [
+                        ['value' => 'on', 'text' => __('On')],
+                        ['value' => 'draft', 'text' => __('Draft')],
+                        ['value' => 'off', 'text' => __('Off')],
+                    ],
+                ],
+                // params (type, name, value)
+                'radio', 'status', '',
+            ],
+            'password' => [
+                // expected result
+                [
+                    'class' => 'password',
+                    'placeholder' => __('new password'),
+                    'autocomplete' => 'new-password',
+                    'default' => '',
+                ],
+                // params (type, name, value)
+                'text', 'password', '',
+            ],
+            'confirm-password' => [
+                // expected result
+                [
+                    'label' => __('Retype password'),
+                    'id' => 'confirm_password',
+                    'name' => 'confirm-password',
+                    'class' => 'confirm-password',
+                    'placeholder' => __('confirm password'),
+                    'autocomplete' => 'new-password',
+                    'default' => '',
+                    'type' => 'password',
+                ],
+                // params (type, name, value)
+                'text', 'confirm-password', '',
+            ],
+            'json' => [
+                // expected result
+                [
+                    'type' => 'textarea',
+                    'class' => 'json',
+                    'value' => json_encode('{ "example": { "this": "is", "an": "example" } }'),
+                ],
+                // params (type, name, value)
+                'json', '', '{ "example": { "this": "is", "an": "example" } }',
+            ],
+        ];
+    }
+
+    /**
+     * Test `getControlOptionFromTypeAndName()` method.
+     *
+     * @param string $expected Expected result.
+     * @param string $type The type (i.e. 'radio', 'text', 'textarea', 'json', etc.)
+     * @param string $name The field name.
+     * @param string $value The field value.
+     * @return void
+     *
+     * @dataProvider getControlOptionFromTypeAndNameSchemaProvider()
+     * @covers ::getControlOptionFromTypeAndName()
+     */
+    public function testGetControlOptionFromTypeAndName(array $expected, $type, $name, $value) : void
+    {
+        $actual = $this->Schema->getControlOptionFromTypeAndName($type, $name, $value);
+
+        static::assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
This provides ordered fields for `core_properties` form, by module (specifying properly in config).
For instance, in `app.php`:
```
'Modules' => [
  // [...]
  'users' => [
            'core_attributes' => [
                'username',
                'password',
                'confirm-password',
                'name',
                'surname',
                'email',
            ],
        ],
]