### PR TITLE
Custom `index` properties + `core`/`other` refactor

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -421,15 +421,29 @@ return [
             'users' => '#555',
             'videos' => '#f03',
         ],
+    ],
 
+    /**
+     * Properties display configuration settings.
+     *
+     * For each module name:
+     *  - 'core' list of properties to present as `core`
+     *  - 'index' properties to display in index view (other than id, status and modified)
+     */
+    'Properties' => [
         'users' => [
-            'core_attributes' => [
+            'core' => [
                 'username',
                 'password',
                 'confirm-password',
                 'name',
                 'surname',
                 'email',
+            ],
+            'index' => [
+                'name',
+                'surname',
+                'username',
             ],
         ],
     ],

--- a/src/Template/Element/Form/core_properties.twig
+++ b/src/Template/Element/Form/core_properties.twig
@@ -1,16 +1,13 @@
-{% set default_core_attributes = ['title', 'description', 'uname', 'status'] %}
-{% set attributes = data.attributes %}
-{% set module = currentModule.name|default('') %}
-{% set core_properties = config('Modules.' ~ module ~ '.core_attributes')|default(default_core_attributes) %}
 
 <div class="tab"><h2>{{ __('Main Properties') }}</h2></div>
 
 <fieldset id="core_properties">
     {{ Form.hidden('id', {'value': object.id})|raw }}
 
-{% for key, fieldName in core_properties %}
-    {% set type = Schema.getControlTypeFromSchema(fieldName) %}
-    {% set options = Schema.getControlOptionFromTypeAndName(type, fieldName, attributes.fieldName) %}
-    {{ Form.control(fieldName, options)|raw }}
+{% for key, value in core_properties %}
+
+    {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
+    {{ Form.control(key, options)|raw }}
+
 {% endfor %}
 </fieldset>

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -1,21 +1,18 @@
 {% element 'Form/_other_properties_script' %}
 
-{% set default_core_attributes = ['title', 'description', 'uname', 'status'] %}
-{% set all_attributes = object.attributes|default([]) %}
-{% set module = currentModule.name|default('') %}
-{% set core_properties = config('Modules.' ~ module ~ '.core_attributes')|default(default_core_attributes) %}
-{% set other_properties = Array.removeKeys(all_attributes, core_properties) %}
-
 <div class="tab"><h2>{{ __('Other Properties') }}</h2></div>
 
 <fieldset id="object_properties">
 {% set jsonKeys = [] %}
-{% for fieldName, value in other_properties %}
-    {% set property = schema.properties[fieldName] %}
-    {% set ptype = Schema.getTypeFromSchema(property) %}
-    {% set type = (ptype == 'json') ? 'json' : Schema.getControlTypeFromSchema(fieldName, ptype) %}
-    {% set options = Schema.getControlOptionFromTypeAndName(type, fieldName, value) %}
-    {{ Form.control(fieldName, options)|raw }}
+{% for key, value in other_properties %}
+
+    {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
+    {% if options.class and  options.class == 'json' %}
+        {% set jsonKeys = jsonKeys|merge([key]) %}
+    {% endif %}
+
+    {{ Form.control(key, options)|raw }}
+
 {% endfor %}
 {% if jsonKeys %}
     {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': jsonKeys|join(',')})|raw }}

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -1,10 +1,14 @@
 {% do _view.assign('title', currentModule.name|humanize) %}
 
+{% set index_properties = config('Properties.' ~ currentModule.name ~ '.index')|default(['title']) %}
+
 <div class="module-content">
 
     <div class="list-objects">
         <nav class="table-header">
-            <div>{{ Link.sort('title')}}</div>
+            {% for prop in index_properties %}
+                <div>{{ Link.sort(prop) }}</div>
+            {% endfor %}
             <div>{{ Link.sort('id')}}</div>
             {% if currentModule.hints.multiple_types %}
                 <div>{{ __('type') }}</div>
@@ -19,7 +23,11 @@
                 href="{{ Url.build({'_name': 'modules:view', 'object_type': object.type, 'id': object.id}) }}"
                 title="{{ object.attributes.title }}"
                 class="object-status-{{ object.attributes.status }}">
-                    <div>{{ object.attributes.title }}</div>
+
+                    {% for prop in index_properties %}
+                        <div>{{ object.attributes[prop] }}</div>
+                    {% endfor %}
+
                     <div>{{ object.id }}</div>
                     {% if currentModule.hints.multiple_types %}
                         <div>{{ object.type }}</div>

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -8,9 +8,11 @@
 
     <h1>{{ object.attributes.title|default(__('New {0}', currentModule.singular)) }}</h1>
 
-    {% element 'Form/core_properties' %}
+    {# Extract `core` & `other` properties sets from object.attributes, pass to elements #}
+    {% set core_properties = config('Properties.' ~ currentModule.name ~ '.core')|default(['title', 'description', 'uname', 'status']) %}
+    {% element 'Form/core_properties' { 'core_properties': Array.onlyKeys(object.attributes, core_properties)} %}
 
-    {% element 'Form/other_properties' %}
+    {% element 'Form/other_properties' { 'other_properties': Array.removeKeys(object.attributes, core_properties)} %}
 
     {% element 'Form/relations' %}
 

--- a/src/View/Helper/ArrayHelper.php
+++ b/src/View/Helper/ArrayHelper.php
@@ -43,4 +43,24 @@ class ArrayHelper extends Helper
     {
         return array_diff_key($arr, array_flip($keys));
     }
+
+    /**
+     * Return array with only specified keys maintaining order.
+     *
+     * @param array $arr The array.
+     * @param array $keys The ordered keys to maintain.
+     * @return array The array with only selected keys.
+     */
+    public function onlyKeys(array $arr, array $keys) : array
+    {
+        $res = [];
+        foreach ($keys as $k) {
+            $res[$k] = null;
+            if (isset($arr[$k])) {
+                $res[$k] = $arr[$k];
+            }
+        }
+
+        return $res;
+    }
 }

--- a/tests/TestCase/View/Helper/ArrayHelperTest.php
+++ b/tests/TestCase/View/Helper/ArrayHelperTest.php
@@ -181,5 +181,4 @@ class ArrayHelperTest extends TestCase
 
         static::assertSame($expected, $actual);
     }
-
 }

--- a/tests/TestCase/View/Helper/ArrayHelperTest.php
+++ b/tests/TestCase/View/Helper/ArrayHelperTest.php
@@ -136,4 +136,50 @@ class ArrayHelperTest extends TestCase
 
         static::assertSame($expected, $actual);
     }
+
+    /**
+     * Data provider for `testOnlyKeys` test case.
+     *
+     * @return array
+     */
+    public function onlyKeysProvider() : array
+    {
+        return [
+            'basic' => [
+                [
+                    'extra' => 'object',
+                    'description' => 'string',
+                ], // expected
+                [
+                    'title' => 'string',
+                    'description' => 'string',
+                    'uname' => 'string',
+                    'status' => 'string',
+                    'extra' => 'object',
+                ], // data
+                [
+                    'extra',
+                    'description'
+                ], // keys to keep
+            ]
+        ];
+    }
+
+    /**
+     * Test `onlyKeys()` method.
+     *
+     * @dataProvider onlyKeysProvider()
+     * @covers ::onlyKeys()
+     * @param array $expected The expected array.
+     * @param array $arr The array.
+     * @param array $keys The keys to keep.
+     * @return void
+     */
+    public function testOnlyKeys(array $expected, array $arr, array $keys)
+    {
+        $actual = $this->Array->onlyKeys($arr, $keys);
+
+        static::assertSame($expected, $actual);
+    }
+
 }

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -54,11 +54,11 @@ class SchemaHelperTest extends TestCase
     }
 
     /**
-     * Data provider for `testGetControlTypeFromSchema` test case.
+     * Data provider for `testControlTypeFromSchema` test case.
      *
      * @return array
      */
-    public function getControlTypeFromSchemaProvider() : array
+    public function controlTypeFromSchemaProvider() : array
     {
         return [
             'string' => [
@@ -117,47 +117,58 @@ class SchemaHelperTest extends TestCase
                     'const' => 13,
                 ],
             ],
-            'unknown type' => [
-                'text',
+            'json' => [
+                'json',
                 [
                     'type' => 'object',
+                ],
+            ],
+            'unknown' => [
+                'text',
+                [
+                    'type' => 'unknown',
                 ],
             ],
         ];
     }
 
     /**
-     * Test `getControlTypeFromSchema()` method.
+     * Test `controlTypeFromSchema()` method.
      *
      * @param string $expected Expected result.
      * @param array|bool $schema Schema.
      * @return void
      *
-     * @dataProvider getControlTypeFromSchemaProvider()
-     * @covers ::getControlTypeFromSchema()
+     * @dataProvider controlTypeFromSchemaProvider()
+     * @covers ::controlTypeFromSchema()
      */
-    public function testGetControlTypeFromSchema(string $expected, $schema) : void
+    public function testControlTypeFromSchema(string $expected, $schema) : void
     {
-        $actual = $this->Schema->getControlTypeFromSchema($schema);
+        $actual = $this->Schema->controlTypeFromSchema($schema);
 
         static::assertSame($expected, $actual);
     }
 
     /**
-     * Data provider for `testGetControlOptionFromTypeAndName` test case.
+     * Data provider for `testControlOptions` test case.
      *
      * @return array
      */
-    public function getControlOptionFromTypeAndNameSchemaProvider() : array
+    public function controlOptionsSchemaProvider() : array
     {
         return [
             'text' => [
                 // expected result
                 [
                     'type' => 'text',
+                    'value' => 'test',
                 ],
-                // params (type, name, value)
-                'text', 'test', '',
+                // schema type
+                [
+                    'type' => 'string',
+                ],
+                'name',
+                'test',
             ],
             'status' => [
                 // expected result
@@ -169,8 +180,12 @@ class SchemaHelperTest extends TestCase
                         ['value' => 'off', 'text' => __('Off')],
                     ],
                 ],
-                // params (type, name, value)
-                'radio', 'status', '',
+                // schema type
+                [
+                    'type' => 'string',
+                ],
+                'status',
+                'on'
             ],
             'password' => [
                 // expected result
@@ -180,8 +195,12 @@ class SchemaHelperTest extends TestCase
                     'autocomplete' => 'new-password',
                     'default' => '',
                 ],
-                // params (type, name, value)
-                'text', 'password', '',
+                // schema type
+                [
+                    'type' => 'string',
+                ],
+                'password',
+                ''
             ],
             'confirm-password' => [
                 // expected result
@@ -195,8 +214,12 @@ class SchemaHelperTest extends TestCase
                     'default' => '',
                     'type' => 'password',
                 ],
-                // params (type, name, value)
-                'text', 'confirm-password', '',
+                // schema type
+                [
+                    'type' => 'string',
+                ],
+                'confirm-password',
+                ''
             ],
             'json' => [
                 // expected result
@@ -205,27 +228,46 @@ class SchemaHelperTest extends TestCase
                     'class' => 'json',
                     'value' => json_encode('{ "example": { "this": "is", "an": "example" } }'),
                 ],
-                // params (type, name, value)
-                'json', '', '{ "example": { "this": "is", "an": "example" } }',
+                // schema type
+                [
+                    'type' => 'object',
+                ],
+                'extra',
+                '{ "example": { "this": "is", "an": "example" } }',
+            ],
+            'title' => [
+                // expected result
+                [
+                    'class' => 'title',
+                    'type' => 'text',
+                ],
+                // schema type
+                [
+                    'type' => 'string',
+                    'contentMediaType' => 'text/html',
+                ],
+                'title',
+                'test',
             ],
         ];
     }
 
     /**
-     * Test `getControlOptionFromTypeAndName()` method.
+     * Test `controlOptions` method.
      *
      * @param string $expected Expected result.
-     * @param string $type The type (i.e. 'radio', 'text', 'textarea', 'json', etc.)
+     * @param array $type The JSON schema type
      * @param string $name The field name.
      * @param string $value The field value.
      * @return void
      *
-     * @dataProvider getControlOptionFromTypeAndNameSchemaProvider()
-     * @covers ::getControlOptionFromTypeAndName()
+     * @dataProvider controlOptionsSchemaProvider()
+     * @covers ::controlOptions()
+     * @covers ::customControlOptions()
      */
-    public function testGetControlOptionFromTypeAndName(array $expected, $type, $name, $value) : void
+    public function testControlOptions(array $expected, $type, $name, $value) : void
     {
-        $actual = $this->Schema->getControlOptionFromTypeAndName($type, $name, $value);
+        $actual = $this->Schema->controlOptions($name, $value, $type);
 
         static::assertSame($expected, $actual);
     }


### PR DESCRIPTION
This PR introduces custom index properties display.

Property display configuration will be like this:
```php
  'Properties' => [
    '{module-name}' => [
      // properties displayed in `sore` group	        
      'core' => [
        'key1',
        'key2'.
      ],	             ],
      // properties displayed in `index`	        
      'index' => [
        'key2',
        'key3'.
      ],	             
    ],
  ],	         ],
```
Here `core` and `index` custom property sets may be defined.

* `SchemaHelper` was refactored with a new `controlOptions` method
* `core_properties.twig` and `other_properties.twig` are being simplified
