### PR TITLE
chore: vue delimiters proposal

### DIFF
--- a/webroot/js/config/config.js
+++ b/webroot/js/config/config.js
@@ -2,4 +2,5 @@
 
 Vue.config.devtools = true;
 
-Vue.options.delimiters = ['@(', ')'];
+// ERB & underscore style delimiters, avoid conflict with Twig {{ }}
+Vue.options.delimiters = ['<%', '%>']


### PR DESCRIPTION
What about ERB style delimiters `<%  '%>`, used also by underscore.js ?

http://ruby-doc.org/stdlib-2.5.0/libdoc/erb/rdoc/ERB.html
http://underscorejs.org/docs/underscore.html#section-165

widely used and no conflicts with Twig `{{ }}` `{% %}` or CakePHP delimiters `<?= =>`
