### PR TITLE
Force `/home` reload + no data if unlogged

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -39,6 +39,7 @@ class ModulesComponent extends Component
     protected $_defaultConfig = [
         'apiClient' => null,
         'currentModuleName' => null,
+        'clearHomeCache' => false,
     ];
 
     /**
@@ -48,6 +49,10 @@ class ModulesComponent extends Component
      */
     public function beforeRender() : void
     {
+        if ($this->getConfig('clearHomeCache')) {
+            Cache::delete(sprintf('home_%d', $this->Auth->user('id')));
+        }
+
         $modules = $this->getModules();
         $project = $this->getProject();
 

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -49,6 +49,12 @@ class ModulesComponent extends Component
      */
     public function beforeRender() : void
     {
+        if (empty($this->Auth->user('id'))) {
+            $this->getController()->set(['modules' => [], 'project' => []]);
+
+            return;
+        }
+
         if ($this->getConfig('clearHomeCache')) {
             Cache::delete(sprintf('home_%d', $this->Auth->user('id')));
         }

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -17,6 +17,16 @@ namespace App\Controller;
  */
 class DashboardController extends AppController
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize() : void
+    {
+        parent::initialize();
+
+        // force `GET /home` reload
+        $this->Modules->setConfig('clearHomeCache', true);
+    }
 
     /**
      * Displays dashboard.

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -465,7 +465,8 @@ class ModulesComponentTest extends TestCase
             ->with('/home')
             ->willReturn(compact('meta'));
 
-        $this->Modules->setConfig(compact('apiClient', 'currentModuleName'));
+        $clearHomeCache = true;
+        $this->Modules->setConfig(compact('apiClient', 'currentModuleName', 'clearHomeCache'));
 
         $controller = $this->Modules->getController();
         $controller->dispatchEvent('Controller.beforeRender');

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -16,6 +16,7 @@ namespace App\Test\TestCase\Controller\Component;
 use App\Controller\Component\ModulesComponent;
 use BEdita\SDK\BEditaClient;
 use BEdita\SDK\BEditaClientException;
+use Cake\Controller\Component\AuthComponent;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
@@ -47,6 +48,7 @@ class ModulesComponentTest extends TestCase
         $registry = $controller->components();
         $registry->load('Auth');
         $this->Modules = $registry->load(ModulesComponent::class);
+        $this->Auth = $registry->load(AuthComponent::class);
     }
 
     /**
@@ -348,6 +350,7 @@ class ModulesComponentTest extends TestCase
     {
         return [
             'without current module' => [
+                1,
                 [
                     'gustavo',
                     'supporto',
@@ -383,6 +386,7 @@ class ModulesComponentTest extends TestCase
                 ],
             ],
             'with current module' => [
+                1,
                 [
                     'gustavo',
                     'supporto',
@@ -418,12 +422,22 @@ class ModulesComponentTest extends TestCase
                 ],
                 'supporto',
             ],
+            'no user' => [
+                null,
+                [],
+                null,
+                [],
+                [],
+                [],
+                null,
+            ],
         ];
     }
 
     /**
      * Test `beforeRender()` method.
      *
+     * @param int|null $userId User id.
      * @param string[] $modules Expected module names.
      * @param string|null $currentModule Expected current module name.
      * @param array $project Expected project info.
@@ -435,9 +449,13 @@ class ModulesComponentTest extends TestCase
      * @dataProvider beforeRenderProvider()
      * @covers ::beforeRender()
      */
-    public function testBeforeRender($modules, ?string $currentModule, array $project, array $meta, array $order = [], ?string $currentModuleName = null) : void
+    public function testBeforeRender($userId, $modules, ?string $currentModule, array $project, array $meta, array $order = [], ?string $currentModuleName = null) : void
     {
         Configure::write('Modules.order', $order);
+
+        if ($userId) {
+            $this->Auth->setUser(['id' => $userId]);
+        }
 
         // Setup mock API client.
         $apiClient = $this->getMockBuilder(BEditaClient::class)


### PR DESCRIPTION
This PR does two things:
1. upon `Dashboard` access `GET /home` on API is forced: this removes unwanted cache data upon login and enables permission changes without logout/login actions
1. if user is not logged no `module` data are available   