### PR TITLE
Redirect on login

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -34,7 +34,6 @@ class LoginController extends AppController
 
         if (!$this->request->is('post')) {
             // Display login form.
-            $this->set('redirect', Hash::get($this->request->getQueryParams(), 'redirect'));
 
             return null;
         }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -14,6 +14,7 @@ namespace App\Controller;
 
 use BEdita\SDK\BEditaClientException;
 use Cake\Http\Response;
+use Cake\Utility\Hash;
 use Psr\Log\LogLevel;
 
 /**
@@ -33,6 +34,8 @@ class LoginController extends AppController
 
         if (!$this->request->is('post')) {
             // Display login form.
+            $this->set('redirect', Hash::get($this->request->getQueryParams(), 'redirect'));
+
             return null;
         }
 

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -14,7 +14,6 @@ namespace App\Controller;
 
 use BEdita\SDK\BEditaClientException;
 use Cake\Http\Response;
-use Cake\Utility\Hash;
 use Psr\Log\LogLevel;
 
 /**
@@ -34,7 +33,6 @@ class LoginController extends AppController
 
         if (!$this->request->is('post')) {
             // Display login form.
-
             return null;
         }
 

--- a/src/Template/Pages/Login/login.twig
+++ b/src/Template/Pages/Login/login.twig
@@ -5,7 +5,7 @@
     {% element 'Messages/messages' %}
 
     {{ Form.create(null, {
-        'url': {'_name': 'login'},
+        'url': {'_name': 'login', 'redirect': redirect },
     })|raw }}
 
     {{ Form.control('username', {

--- a/src/Template/Pages/Login/login.twig
+++ b/src/Template/Pages/Login/login.twig
@@ -5,7 +5,7 @@
     {% element 'Messages/messages' %}
 
     {{ Form.create(null, {
-        'url': {'_name': 'login', 'redirect': redirect },
+        'url': {'_name': 'login', 'redirect': _view.request.getQuery('redirect') },
     })|raw }}
 
     {{ Form.control('username', {


### PR DESCRIPTION
This PR will allow proper `redirect` on login.

E.g. when user session is terminated user is redirected to an url like `/login?redirect=/documents`.
After a successful login user is now properly redirected to `/documents` as expected.
