### PR TITLE
Enum schema type

### DIFF
--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -13,6 +13,7 @@
 
 namespace App\View\Helper;
 
+use Cake\Utility\Hash;
 use Cake\View\Helper;
 
 /**
@@ -57,6 +58,9 @@ class SchemaHelper extends Helper
                 }
                 if (!empty($schema['contentMediaType']) && $schema['contentMediaType'] === 'text/html') {
                     return 'textarea';
+                }
+                if (!empty($schema['enum']) && is_array($schema['enum'])) {
+                    return 'enum';
                 }
 
                 return 'text';
@@ -156,6 +160,13 @@ class SchemaHelper extends Helper
                 'type' => 'text',
                 'v-datepicker' => '',
                 'time' => 'true',
+            ];
+        } elseif ($type === 'enum') {
+            return [
+                'type' => 'select',
+                'options' => Hash::map($schema['enum'], '{n}', function ($v) {
+                    return ['value' => $v, 'text' => $v];
+                }),
             ];
         }
 

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -13,7 +13,7 @@
 
 namespace App\View\Helper;
 
-use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
 use Cake\View\Helper;
 
 /**
@@ -164,9 +164,12 @@ class SchemaHelper extends Helper
         } elseif ($type === 'enum') {
             return [
                 'type' => 'select',
-                'options' => Hash::map($schema['enum'], '{n}', function ($v) {
-                    return ['value' => $v, 'text' => $v];
-                }),
+                'options' => array_map(
+                    function ($value) {
+                        return ['value' => $value, 'text' => Inflector::humanize($value)];
+                    },
+                    $schema['enum']
+                ),
             ];
         }
 

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -295,7 +295,7 @@ class SchemaHelperTest extends TestCase
                     'v-datepicker' => '',
                     'time' => 'true',
                 ],
-                // schema
+                // schema type
                 [
                     'type' => 'string',
                     'format' => 'date-time',
@@ -312,7 +312,7 @@ class SchemaHelperTest extends TestCase
                         ['value' => 'bad', 'text' => 'bad'],
                     ],
                 ],
-                // schem
+                // schema type
                 [
                     'type' => 'string',
                     'enum' => [
@@ -329,7 +329,7 @@ class SchemaHelperTest extends TestCase
     /**
      * Test `controlOptions` method.
      *
-     * @param string $expected Expected result.
+     * @param array $expected Expected result.
      * @param array $schema The JSON schema
      * @param string $name The field name.
      * @param string $value The field value.
@@ -339,7 +339,7 @@ class SchemaHelperTest extends TestCase
      * @covers ::controlOptions()
      * @covers ::customControlOptions()
      */
-    public function testControlOptions(array $expected, $schema, $name, $value) : void
+    public function testControlOptions(array $expected, array $schema, $name, $value) : void
     {
         $actual = $this->Schema->controlOptions($name, $value, $schema);
 

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -308,8 +308,8 @@ class SchemaHelperTest extends TestCase
                 [
                     'type' => 'select',
                     'options' => [
-                        ['value' => 'good', 'text' => 'good'],
-                        ['value' => 'bad', 'text' => 'bad'],
+                        ['value' => 'good', 'text' => 'Good'],
+                        ['value' => 'bad', 'text' => 'Bad'],
                     ],
                 ],
                 // schema type

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -75,11 +75,10 @@ class SchemaHelperTest extends TestCase
                 ],
             ],
             'date' => [
-                'text', // TODO: replace with "datetime".
+                'date-time',
                 [
-                    'type' => 'text',
-                        'v-datepicker' => '',
-                        'time' => 'true',
+                    'type' => 'string',
+                    'format' => 'date-time',
                 ],
             ],
             'number' => [
@@ -128,6 +127,13 @@ class SchemaHelperTest extends TestCase
                 'text',
                 [
                     'type' => 'unknown',
+                ],
+            ],
+            'enum' => [
+                'enum',
+                [
+                    'type' => 'string',
+                    'enum' => ['a', 'b', 'c'],
                 ],
             ],
         ];
@@ -282,6 +288,41 @@ class SchemaHelperTest extends TestCase
                 'body',
                 'test',
             ],
+            'publish_start' => [
+                // expected result
+                [
+                    'type' => 'text',
+                    'v-datepicker' => '',
+                    'time' => 'true',
+                ],
+                // schema
+                [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                ],
+                'publish_start',
+                'test',
+            ],
+            'enum' => [
+                // expected result
+                [
+                    'type' => 'select',
+                    'options' => [
+                        ['value' => 'good', 'text' => 'good'],
+                        ['value' => 'bad', 'text' => 'bad'],
+                    ],
+                ],
+                // schem
+                [
+                    'type' => 'string',
+                    'enum' => [
+                        'good',
+                        'bad',
+                    ],
+                ],
+                'enum',
+                'good',
+            ],
         ];
     }
 
@@ -289,7 +330,7 @@ class SchemaHelperTest extends TestCase
      * Test `controlOptions` method.
      *
      * @param string $expected Expected result.
-     * @param array $type The JSON schema type
+     * @param array $schema The JSON schema
      * @param string $name The field name.
      * @param string $value The field value.
      * @return void
@@ -298,9 +339,9 @@ class SchemaHelperTest extends TestCase
      * @covers ::controlOptions()
      * @covers ::customControlOptions()
      */
-    public function testControlOptions(array $expected, $type, $name, $value) : void
+    public function testControlOptions(array $expected, $schema, $name, $value) : void
     {
-        $actual = $this->Schema->controlOptions($name, $value, $type);
+        $actual = $this->Schema->controlOptions($name, $value, $schema);
 
         static::assertSame($expected, $actual);
     }


### PR DESCRIPTION
This PR adds `enum` JSON Schema type to `SchemaHelper`.

A refactor of `SchemaHelper` will be soon necessary, only minimal changes for now.
