### PR TITLE
Element override from a plugin via configuration

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -462,6 +462,25 @@ return [
     ],
 
     /**
+     * Custom view elements configuration.
+     * Load an element from a `Plugin` and not from core App inside a module.
+     *
+     * Example configuration:
+     *
+     * ```
+     *   'documents` => [
+     *     'Form/included' => 'MyPlugin',
+     *  ],
+     * ```
+     * In this example: if current module is `documents` => `Form/included` element is loaded from `MyPlugin` plugin
+     */
+    'Elements' => [
+        // 'documents' => [
+        //     'Form/included' => 'MyPlugin',
+        // ],
+    ],
+
+    /**
      * Additional plugins to load with this format: 'PluginName' => load options array
      * Where options array may contain
      *

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -13,6 +13,8 @@
 namespace App\View;
 
 use App\View\Twig\BeditaTwigExtension;
+use Cake\Core\Configure;
+use Cake\Utility\Hash;
 use WyriHaximus\TwigView\View\TwigView;
 
 /**
@@ -48,5 +50,23 @@ class AppView extends TwigView
 
         $this->getTwig()
             ->addExtension(new BeditaTwigExtension());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Retrieve custom view `element` from configuration mappings.
+     *
+     * If `Elements.{module_name}.{element_name}` exists in configuration a custom element is loaded
+     */
+    protected function _getElementFileName($name, $pluginCheck = true)
+    {
+        $module = $this->get('currentModule');
+        $custom = Configure::read(sprintf('Elements.%s', Hash::get($module, 'name', '')));
+        if (!empty($custom[$name])) {
+            $name = sprintf('%s.%s', $custom[$name], $name);
+        }
+
+        return parent::_getElementFileName($name, $pluginCheck);
     }
 }

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -61,7 +61,7 @@ class AppView extends TwigView
      */
     protected function _getElementFileName($name, $pluginCheck = true)
     {
-        $module = $this->get('currentModule');
+        $module = (array)$this->get('currentModule', []);
         $custom = Configure::read(sprintf('Elements.%s', Hash::get($module, 'name', '')));
         if (!empty($custom[$name])) {
             $name = sprintf('%s.%s', $custom[$name], $name);

--- a/tests/TestCase/View/AppViewTest.php
+++ b/tests/TestCase/View/AppViewTest.php
@@ -40,7 +40,7 @@ class AppViewTest extends TestCase
     }
 
     /**
-     * Test `initialize` method
+     * Test `_getElementFileName` method
      *
      * @return void
      * @covers ::_getElementFileName()

--- a/tests/TestCase/View/AppViewTest.php
+++ b/tests/TestCase/View/AppViewTest.php
@@ -36,6 +36,7 @@ class AppViewTest extends TestCase
         $View = new AppView();
         $extensions = $View->getTwig()->getExtensions();
         static::assertNotEmpty($extensions);
+        static::assertArrayHasKey('bedita', $extensions);
     }
 
     /**

--- a/tests/TestCase/View/AppViewTest.php
+++ b/tests/TestCase/View/AppViewTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\View;
+
+use App\View\AppView;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\View\AppView} Test Case
+ *
+ * @coversDefaultClass \App\View\AppView
+ */
+class AppViewTest extends TestCase
+{
+
+    /**
+     * Test `initialize` method
+     *
+     * @return void
+     * @covers ::initialize()
+     */
+    public function testInitialize() : void
+    {
+        $View = new AppView();
+        $extensions = $View->getTwig()->getExtensions();
+        static::assertNotEmpty($extensions);
+    }
+
+    /**
+     * Test `initialize` method
+     *
+     * @return void
+     * @covers ::_getElementFileName()
+     */
+    public function testCustomElement() : void
+    {
+        $View = new AppView();
+        $View->viewVars['currentModule'] = ['name' => 'cats'];
+        $result = $View->elementExists('Form/meta');
+        static::assertTrue($result);
+
+        $custom = [
+            'cats' => [
+                'Form/meta' => 'MyPlugin',
+            ],
+        ];
+        Configure::write('Elements', $custom);
+        $result = $View->elementExists('Form/meta');
+        static::assertFalse($result);
+    }
+}


### PR DESCRIPTION
Using a configuration like this:
```php
    'Elements' => [
        'documents' => [
            'Form/included' => 'MyPlugin',
        ],
    ],
```
We are able to override an element: if we're in `documents` module we can use `MyPlugin.Form/included` instead of `Form/included`

Is there a better way to do this with Cake?
