### PR TITLE
feat: country codes with league/iso3166

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "cakephp/migrations": "^1.0",
         "cakephp/plugin-installer": "^1.0",
         "josegonzalez/dotenv": "2.*",
+        "league/iso3166": "^2.0",
         "mobiledetect/mobiledetectlib": "2.*",
         "php-http/guzzle6-adapter": "^1.1",
         "woohoolabs/yang": "^1.4",

--- a/src/Core/Countries.php
+++ b/src/Core/Countries.php
@@ -15,7 +15,7 @@ class Countries
      * Return list of countries pairs <code> =>  >name> by specified code
      *
      * @param string $code The code type: can be alpha2, alpha3, numeric, name
-     * @return array The countries list (<code>: <name>)
+     * @return array The countries list
      */
     public function list($code = 'alpha3') : array
     {

--- a/src/Core/Countries.php
+++ b/src/Core/Countries.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Core;
+
+use Cake\Utility\Hash;
+use League\ISO3166\ISO3166;
+
+/**
+ * Countries class
+ * @uses League\ISO3166\ISO3166 to get countries data
+ */
+class Countries
+{
+    /**
+     * Return list of countries pairs <code> =>  >name> by specified code
+     *
+     * @param string $code The code type: can be alpha2, alpha3, numeric, name
+     * @return array The countries list (<code>: <name>)
+     */
+    public function list($code = 'alpha3') : array
+    {
+        $all = (new ISO3166)->all();
+
+        return Hash::combine($all, sprintf('{n}.%s', $code), '{n}.name');
+    }
+}

--- a/tests/TestCase/Core/CountriesTest.php
+++ b/tests/TestCase/Core/CountriesTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\Core;
+
+use Cake\TestSuite\TestCase;
+use OpenCorporation\Core\Countries;
+
+/**
+ * {@see \App\Core\Countries} Test Case
+ *
+ * @coversDefaultClass \App\Core\Countries
+ */
+class CountriesTest extends TestCase
+{
+    /**
+     * Data provider for `testList` test case.
+     *
+     * @return array
+     */
+    public function listProvider() : array
+    {
+        return [
+            'alpha2' => [
+                'alpha2',
+                249,
+            ],
+            'alpha3' => [
+                'alpha3',
+                249,
+            ],
+            'numeric' => [
+                'numeric',
+                249,
+            ],
+            'name' => [
+                'name',
+                249,
+            ],
+        ];
+    }
+
+    /**
+     * Test `list` method
+     *
+     * @param string $code The code, can be alpha2, alpha3, numeric, name
+     * @param int $size Expected number of countries
+     * @return void
+     * @dataProvider listProvider()
+     * @covers ::list()
+     */
+    public function testList($code, $size) : void
+    {
+        $countries = new Countries();
+        $result = $countries->list($code);
+        static::assertNotEmpty($result);
+        static::assertEquals(count($result), $size);
+    }
+}

--- a/tests/TestCase/Core/CountriesTest.php
+++ b/tests/TestCase/Core/CountriesTest.php
@@ -13,8 +13,8 @@
 
 namespace App\Test\TestCase\Core;
 
+use App\Core\Countries;
 use Cake\TestSuite\TestCase;
-use OpenCorporation\Core\Countries;
 
 /**
  * {@see \App\Core\Countries} Test Case


### PR DESCRIPTION
This provides country iso codes using league/iso3166 (https://github.com/thephpleague/iso3166).
Core model `Countries` and test unit `CountriesTest`.