### PR TITLE
Properties custom groups

### DIFF
--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -95,8 +95,10 @@ class PropertiesComponent extends Component
         $properties = $used = [];
         $keep = $this->getConfig(sprintf('Properties.%s.view._keep', $type), []);
         $attributes = array_merge(array_fill_keys($keep, ''), $object['attributes']);
+        $defaults = array_merge($this->getConfig(sprintf('Properties.%s.view', $type), []), $this->defaultGroups['view']);
+        unset($defaults['_keep']);
 
-        foreach ($this->defaultGroups['view'] as $group => $items) {
+        foreach ($defaults as $group => $items) {
             $key = sprintf('Properties.%s.view.%s', $type, $group);
             $list = $this->getConfig($key, $items);
             $p = [];

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -1,13 +1,18 @@
+{# Remaining properties groups: 'other' and custom groups not in 'core', '_keep', 'publish', 'advanced' #}
+{% set otherProperties = Array.removeKeys(properties, ['core', '_keep', 'publish', 'advanced']) %}
+{% for group, props in otherProperties %}
+
 <property-view inline-template :tab-open="tabsOpen">
-    <section class="fieldset order-{{ cssOrder }}" id="other_properties" :class="isOpen? '' : 'closed'">
+
+    <section class="fieldset order-{{ cssOrder }}" id="{{ group|underscore }}_properties" :class="isOpen? '' : 'closed'">
 
         <header @click.prevent="toggleVisibility()" class="tab unselectable">
-            <h2>{{ __('Content') }}</h2>
+            <h2>{{ __(group|humanize) }}</h2>
         </header>
 
         <div v-show="isOpen" class="tab-container">
             {% set jsonKeys = [] %}
-            {% for key, value in properties.other %}
+            {% for key, value in props %}
 
                 {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
                 {% if options.class and  options.class == 'json' %}
@@ -23,4 +28,7 @@
         </div>
 
     </section>
+
 </property-view>
+
+{% endfor %}

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -143,15 +143,16 @@ class PropertiesComponentTest extends TestCase
                     'core' => [
                         'title' => 'A',
                     ],
+                    'advanced' => [
+                        'json_field' => 'json',
+                    ],
                     'publish' => [
                         'uname' => 'test',
                         'status' => 'draft',
                     ],
-                    'advanced' => [
-                        'json_field' => 'json',
-                    ],
                     'other' => [
                         'description' => 'desc',
+                        'other_field' => null,
                     ],
                 ],
                 [
@@ -161,6 +162,7 @@ class PropertiesComponentTest extends TestCase
                         'status' => 'draft',
                         'json_field' => 'json',
                         'uname' => 'test',
+                        'other_field' => null,
                     ],
                 ],
                 'geeks',
@@ -208,6 +210,44 @@ class PropertiesComponentTest extends TestCase
                     ],
                 ]
             ],
+            'custom groups' => [
+                [
+                    'core' => [
+                        'title' => 'A',
+                    ],
+                    'publish' => [
+                        'status' => 'on',
+                    ],
+                    'advanced' => [
+                    ],
+                    'custom' => [
+                        'model' => 'bianchi',
+                    ],
+                    'other' => [
+                        'color' => 'blue',
+                    ],
+                ],
+                [
+                    'attributes' => [
+                        'title' => 'A',
+                        'status' => 'on',
+                        'color' => 'blue',
+                        'model' => 'bianchi',
+                    ],
+                ],
+                'bikes',
+                [
+                    'core' => [
+                        'title',
+                    ],
+                    'publish' => [
+                        'status',
+                    ],
+                    'custom' => [
+                        'model',
+                    ],
+                ]
+            ],
         ];
     }
 
@@ -234,6 +274,6 @@ class PropertiesComponentTest extends TestCase
 
         $result = $this->Properties->viewGroups($object, $type);
 
-        static::assertSame($expected, $result);
+        static::assertSame(sort($expected), sort($result));
     }
 }


### PR DESCRIPTION
Thi PR adds custom groups feature in objects view.
In configuration you may define custom groups other than `core`, `publish`, `advanced` and `other` simply like this:

```php

   'Properties' => [
        'players' => [
            'view' => [
                'core' => [
                    'name',
                    'surname',
                ],
                'team_data' => [
                    'shirt_number',
                    'team',
                    'seasons',
                ],
            ],
            'index' => [
                'title',
                'project_status',
            ],
        ],
 ],
```



 