### PR TITLE
fix: avoid warning if Plugins conf missing

### DIFF
--- a/src/View/Helper/LinkHelper.php
+++ b/src/View/Helper/LinkHelper.php
@@ -169,7 +169,7 @@ class LinkHelper extends Helper
      */
     public function pluginsJsBundle()
     {
-        $plugins = Configure::read('Plugins');
+        $plugins = Configure::read('Plugins', []);
         foreach ($plugins as $plugin => $v) {
             $path = Plugin::path($plugin) . sprintf('webroot%sjs%s%s.plugin.js', DS, DS, $plugin);
             if (file_exists($path)) {


### PR DESCRIPTION
Simply set an empty array as default value if `Plugins` conf is missing.