### PR TITLE
Display image and video thumbs in related object cards

### DIFF
--- a/src/Template/Element/Form/relation.twig
+++ b/src/Template/Element/Form/relation.twig
@@ -38,13 +38,13 @@
                             v-bind:class="related.type">
 
                         <header>
-                            <h1><: related.attributes.title || related.attributes.name :></h1>
+                            <h1><a :href="buildViewUrl(related.type, related.id)" target="_blank"><: related.attributes.title || related.attributes.name :></a></h1>
                             <span class="has-text-size-smaller prop-id"><: related.id :></span>
                         </header>
 
-                        <div class="thumbnail" v-if="related.type == 'images'">
+                        <div class="thumbnail" v-if="related.meta.url">
                             <figure>
-                                <img src="https://source.unsplash.com/random" />
+                                <img :src="related.meta.url" />
                             </figure>
                         </div>
 

--- a/src/Template/Element/Form/relations.scss
+++ b/src/Template/Element/Form/relations.scss
@@ -103,7 +103,8 @@
             }
         }
 
-        &.images {
+        &.images,
+        &.videos {
             div.thumbnail {
                 display: block;
             }

--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -1186,7 +1186,7 @@ nav.pagination {
           display: block;
           height: 100%;
           transform: translateX(-50%); }
-    .related-object article.images div.thumbnail {
+    .related-object article.images div.thumbnail, .related-object article.videos div.thumbnail {
       display: block; }
     .related-object article footer {
       position: relative;


### PR DESCRIPTION
In this PR: video thumbnail urls and images are displayed in related objects view if avilable.

TODO: use proper thumbnail for images
 