### PR TITLE
Plugin modules

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -501,6 +501,29 @@ return [
     ],
 
     /**
+     * Plugin modules settings.
+     *
+     * Default empty.
+     * Configuration generally written by plugins via bootstrap.
+     */
+    'PluginModules' => [
+        /*
+        // plugin module example
+        // unique name
+        'My Module' => [
+            'title' => 'My Module',
+            // routing rules
+            'route' => Router::url(['_name': 'my_module:index']),
+            // css class
+            'class' => [
+                'dashboard' => 'has-background-black icon-sample',
+                'menu' => 'has-background-black',
+            ],
+        ],
+        */
+    ],
+
+    /**
      * Pagination default settings
      *
      * - sizeAvailable => available page size on modules view index

--- a/src/Template/Element/Menu/menu.twig
+++ b/src/Template/Element/Menu/menu.twig
@@ -1,17 +1,22 @@
 <ul role="menu">
-    {# <li>
-        {{ Html.link(__(''), {'_name': 'dashboard'}, {'title': __('Dashboard')})|raw }}
-    </li> #}
 
-    {% for module in modules %}
-    {% if module.name != "trash" %}
+    {# Core object modules #}
+    {% for module in modules if module.name != 'trash' %}
         <li class="has-background-module-{{ module.name }} {{ module.name == currentModule.name ? 'current' : '' }}">
             {{ Html.link(
                 module.name|humanize|slice(0, 2),
                 {'controller': 'Modules', 'action': 'index', 'object_type': module.name, 'plugin': null},
                 {'tooltip': module.name|humanize})|raw }}
         </li>
-    {% endif %}
+    {% endfor %}
+
+    {# Plugin modules #}
+    {% for k, plugin in config('PluginModules') %}
+        <li class="{{ plugin.class.menu }}">
+            {{ Html.link(plugin.title|humanize|slice(0, 2),
+                plugin.route,
+                {'tooltip': plugin.title|humanize})|raw }}
+        </li>
     {% endfor %}
 
     {% if currentModule.name != "trash" %}

--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -11,6 +11,11 @@
                 </li>
             {% endif %}
         {% endfor %}
+        {% for k, plugin in config('PluginModules') %}
+            <li class="{{ plugin.class.dashboard }}">
+                {{ Html.link(plugin.title|humanize, plugin.route, {'title': plugin.title|humanize})|raw }}
+            </li>
+        {% endfor %}
         </ul>
     </section>
 

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -12,6 +12,7 @@
  */
 namespace App\View\Helper;
 
+use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
@@ -47,11 +48,7 @@ class LayoutHelper extends Helper
      */
     public function secondarySidebar() : bool
     {
-        if (in_array($this->_View->name, ['Import', 'UserProfile', 'Model'])) {
-            return true;
-        }
-
-        return !empty($this->_View->viewVars['currentModule']);
+        return !in_array($this->_View->name, ['Dashboard', 'Login']);
     }
 
     /**
@@ -81,7 +78,7 @@ class LayoutHelper extends Helper
      */
     public function layoutFooter() : bool
     {
-        return !empty($this->_View->viewVars['currentModule']);
+        return !in_array($this->_View->name, ['Dashboard', 'Login']);
     }
 
     /**
@@ -126,6 +123,11 @@ class LayoutHelper extends Helper
      */
     protected function commandLinkClass() : string
     {
+        $pluginClass = (string)Configure::read(sprintf('PluginModules.%s.class.dashboard', $this->_View->name));
+        if ($pluginClass) {
+            return $pluginClass;
+        }
+
         $moduleClasses = [
             'UserProfile' => 'has-background-black icon-user',
             'Import' => 'has-background-black icon-download-alt',

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -79,11 +79,6 @@ class LayoutHelperTest extends TestCase
                 null,
                 true,
             ],
-            'currentModule empty' => [
-                null,
-                null,
-                false,
-            ],
             'currentModule not empty' => [
                 null,
                 'Objects',
@@ -173,8 +168,12 @@ class LayoutHelperTest extends TestCase
     public function layoutFooterProvider() : array
     {
         return [
-            'currentModule empty' => [
-                null,
+            'login' => [
+                'Login',
+                false,
+            ],
+            'dashboard' => [
+                'Dashboard',
                 false,
             ],
             'currentModule not empty' => [
@@ -193,11 +192,10 @@ class LayoutHelperTest extends TestCase
      * @dataProvider layoutFooterProvider()
      * @covers ::layoutFooter()
      */
-    public function testLayoutFooter($currentModule, $expected) : void
+    public function testLayoutFooter($name, $expected) : void
     {
-        $view = new View();
-        $view->set('currentModule', $currentModule);
-        $layout = new LayoutHelper($view);
+        $data = ['name' => $name];
+        $layout = new LayoutHelper(new View(null, null, null, $data));
         $result = $layout->layoutFooter();
         static::assertSame($result, $expected);
     }

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -186,7 +186,7 @@ class LayoutHelperTest extends TestCase
     /**
      * Test layoutFooter
      *
-     * @param string $currentModule The current module
+     * @param string $name View name
      * @param bool $expected The expected result
      *
      * @dataProvider layoutFooterProvider()


### PR DESCRIPTION
Custom modules may be defined in plugins via configuration key `'PluginModules'`.
Usually this configuration is written by plugin bootstrap.

```php
    'PluginModules' => [
        // unique name
        'My Module' => [
            'title' => 'My Module',
            // main module url
            'route' => Router::url(['_name': 'my_module:index']),
            // css class
            'class' => [
                'dashboard' => 'has-background-black icon-sample',
                'menu' => 'has-background-black',
            ],
        ],
    ],
```
These modules are then displayed in dashboard and top-level menu.