### PR TITLE
Fix `json` formatting in all elements

### DIFF
--- a/src/Template/Element/Form/advanced_properties.twig
+++ b/src/Template/Element/Form/advanced_properties.twig
@@ -7,23 +7,19 @@
     </header>
 
     <div v-show="isOpen" class="tab-container">
-        {% set jsonKeys = [] %}
 
         {% for key, value in properties.advanced %}
 
             {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
 
-            {% if options.class and  options.class == 'json' %}
-                {% set jsonKeys = jsonKeys|merge([key]) %}
-            {% endif %}
-
             {{ Form.control(key, options)|raw }}
+
+            {% if options.class == 'json' %}
+                {{ write_config('_jsonKeys', config('_jsonKeys')|merge([key])) }}
+            {% endif %}
 
         {% endfor %}
 
-        {% if jsonKeys %}
-            {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': jsonKeys|join(',')})|raw }}
-        {% endif %}
     </div>
 
 </section>

--- a/src/Template/Element/Form/advanced_properties.twig
+++ b/src/Template/Element/Form/advanced_properties.twig
@@ -15,7 +15,7 @@
             {{ Form.control(key, options)|raw }}
 
             {% if options.class == 'json' %}
-                {{ write_config('_jsonKeys', config('_jsonKeys')|merge([key])) }}
+                {{ write_config('_jsonKeys', config('_jsonKeys', [])|merge([key])) }}
             {% endif %}
 
         {% endfor %}

--- a/src/Template/Element/Form/core_properties.twig
+++ b/src/Template/Element/Form/core_properties.twig
@@ -3,6 +3,11 @@
         {% for key, value in properties.core %}
             {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
             {{ Form.control(key, options)|raw }}
+
+            {% if options.class == 'json' %}
+                {{ write_config('_jsonKeys', config('_jsonKeys')|merge([key])) }}
+            {% endif %}
+
         {% endfor %}
 
         {{ Form.hidden('id', {'value': (object) ? object.id : resource.id})|raw }}

--- a/src/Template/Element/Form/core_properties.twig
+++ b/src/Template/Element/Form/core_properties.twig
@@ -5,7 +5,7 @@
             {{ Form.control(key, options)|raw }}
 
             {% if options.class == 'json' %}
-                {{ write_config('_jsonKeys', config('_jsonKeys')|merge([key])) }}
+                {{ write_config('_jsonKeys', config('_jsonKeys', [])|merge([key])) }}
             {% endif %}
 
         {% endfor %}

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -11,20 +11,17 @@
         </header>
 
         <div v-show="isOpen" class="tab-container">
-            {% set jsonKeys = [] %}
             {% for key, value in props %}
 
                 {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
-                {% if options.class and  options.class == 'json' %}
-                    {% set jsonKeys = jsonKeys|merge([key]) %}
-                {% endif %}
 
                 {{ Form.control(key, options)|raw }}
 
+                {% if options.class == 'json' %}
+                    {{ write_config('_jsonKeys', config('_jsonKeys')|merge([key])) }}
+                {% endif %}
+
             {% endfor %}
-            {% if jsonKeys %}
-                {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': jsonKeys|join(',')})|raw }}
-            {% endif %}
         </div>
 
     </section>

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -18,7 +18,7 @@
                 {{ Form.control(key, options)|raw }}
 
                 {% if options.class == 'json' %}
-                    {{ write_config('_jsonKeys', config('_jsonKeys')|merge([key])) }}
+                    {{ write_config('_jsonKeys', config('_jsonKeys', [])|merge([key])) }}
                 {% endif %}
 
             {% endfor %}

--- a/src/Template/Element/Form/publish_properties.twig
+++ b/src/Template/Element/Form/publish_properties.twig
@@ -5,7 +5,7 @@
             {{ Form.control(key, options)|raw }}
 
             {% if options.class == 'json' %}
-                {{ write_config('_jsonKeys', config('_jsonKeys')|merge([key])) }}
+                {{ write_config('_jsonKeys', config('_jsonKeys', [])|merge([key])) }}
             {% endif %}
 
         {% endfor %}

--- a/src/Template/Element/Form/publish_properties.twig
+++ b/src/Template/Element/Form/publish_properties.twig
@@ -3,6 +3,11 @@
         {% for key, value in properties.publish %}
             {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
             {{ Form.control(key, options)|raw }}
+
+            {% if options.class == 'json' %}
+                {{ write_config('_jsonKeys', config('_jsonKeys')|merge([key])) }}
+            {% endif %}
+
         {% endfor %}
     </div>
 </section>

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -59,7 +59,7 @@
             {% element 'Form/relations' %}
 
         {# Set `_jsonKeys` hidden input from config #}
-        {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': config('_jsonKeys')|join(',')})|raw }}
+        {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': config('_jsonKeys', [])|join(',')})|raw }}
 
         {{ Form.end()|raw }}
 

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -21,6 +21,10 @@
             'id': 'form-main',
         })|raw }}
 
+
+            {# Init `_jsonKeys` data #}
+            {{ write_config('_jsonKeys', []) }}
+
             {# Inside form-column there are form elements, they may have a cssOrder property that reorders
                 the elements in single column view, in small viewports. cssOrder may assume the string
                 values "1", "2", "3" or "bottom". If missing, the default for cssOrder in "0". #}
@@ -53,6 +57,9 @@
             {# temp relations view #}
             {# loads first relation after 1200ms, than every 300ms till last relation, see file #}
             {% element 'Form/relations' %}
+
+        {# Set `_jsonKeys` hidden input from config #}
+        {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': config('_jsonKeys')|join(',')})|raw }}
 
         {{ Form.end()|raw }}
 

--- a/src/View/Twig/BeditaTwigExtension.php
+++ b/src/View/Twig/BeditaTwigExtension.php
@@ -38,7 +38,12 @@ class BeditaTwigExtension extends \Twig_Extension
     {
         return [
             new \Twig_SimpleFunction('config', [Configure::class, 'read']),
-            new \Twig_SimpleFunction('write_config', [Configure::class, 'write']),
+            new \Twig_SimpleFunction('write_config', function ($key, $val) {
+                // avoid unwanted return value display in templates
+                Configure::write($key, $val);
+
+                return;
+            }),
         ];
     }
 

--- a/src/View/Twig/BeditaTwigExtension.php
+++ b/src/View/Twig/BeditaTwigExtension.php
@@ -38,6 +38,7 @@ class BeditaTwigExtension extends \Twig_Extension
     {
         return [
             new \Twig_SimpleFunction('config', [Configure::class, 'read']),
+            new \Twig_SimpleFunction('write_config', [Configure::class, 'write']),
         ];
     }
 


### PR DESCRIPTION
This PR fixes a bug with `json` input fields.

When a `json` property is used in elements other than `advanced` JSON formatting via `_jsonKeys` is not working as expected.

 * a `_jsonKeys` configuration is used to easily share and update keys
 * a new `write_config` Twig function has been introduced

TODO: there's a formatting issue, probably caused by moving `{{ Form.control('_jsonKeys',...) }}` stil to be fixed.
