### PR TITLE
fix: add stability flag for monolog dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "woohoolabs/yang": "^1.4",
         "wyrihaximus/twig-view": "^4.2",
         "bedita/php-sdk": "dev-master",
+        "monolog/monolog": "@dev",
         "wikimedia/composer-merge-plugin": "^1.4"
     },
     "require-dev": {


### PR DESCRIPTION
https://github.com/bedita/php-sdk/pull/18 has introduced a dependence to `monolog/monolog` dev.

This PR add a stability flag `@dev` on `monolog` to avoid conflicts on `composer install/update`