### PR TITLE
Initialize API log in `debug` mode

### DIFF
--- a/src/ApiClientProvider.php
+++ b/src/ApiClientProvider.php
@@ -53,6 +53,11 @@ class ApiClientProvider
     {
         $this->apiClient = new BEditaClient(Configure::read('API.apiBaseUrl'), Configure::read('API.apiKey'));
 
+        // init logger in `debug` mode
+        if (Configure::read('debug')) {
+            $this->apiClient->initLogger(['log_file' => LOGS . 'api.log']);
+        }
+
         return $this->apiClient;
     }
 


### PR DESCRIPTION
After bedita/php-sdk#18 we are able to introduce basic API request / response logging.
In this PR: log activated in `logs/api.log` when `debug` config is set.
Do we need another configuration to enable api logging?
