### PR TITLE
feat: hide import if no import filters available

### DIFF
--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -24,9 +24,11 @@
             <li class="has-background-module-trash icon-trash-2">
                 {{ Html.link(__('Trash can'), {'controller': 'Modules', 'action': 'index', 'object_type': 'trash'}, {'title': __('Trash')})|raw }}
             </li>
+            {% if config('Filters.import') %}
             <li class="has-background-black icon-download-alt">
                 {{ Html.link(__('Import'), {'_name': 'import:index'})|raw }}
             </li>
+            {% endif %}
             {% if in_array('admin', user.roles) %}
             <li class="has-background-black icon-database">
                 {{ Html.link(__('Model'), {'_name': 'model:list', 'resource_type': 'object_types'})|raw }}


### PR DESCRIPTION
This hides `Import` module link, when no import filters are available.
This fixes #154 