### PR TITLE
Improve file import error messages

### DIFF
--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -13,6 +13,7 @@
 namespace App\Controller;
 
 use Cake\Core\Configure;
+use Cake\Core\Exception as CakeException;
 use Cake\Event\Event;
 use Cake\Http\Response;
 use Cake\Network\Exception\BadRequestException;
@@ -61,7 +62,7 @@ class ImportController extends AppController
             $importFilter = new $filter($this->apiClient);
 
             // see http://php.net/manual/en/features.file-upload.errors.php
-            $fileError = $this->request->getData('file.error', 4);
+            $fileError = (int)$this->request->getData('file.error', 4);
             if ($fileError > 0) {
                 throw new BadRequestException($this->uploadErrorMessage($fileError));
             }
@@ -72,7 +73,8 @@ class ImportController extends AppController
             );
             $this->set(compact('result'));
         } catch (Exception $e) {
-            $this->Flash->error($e, ['params' => $e->getAttributes()]);
+            $params = $e instanceof CakeException ? $e->getAttributes() : [];
+            $this->Flash->error($e, compact('params'));
 
             return $this->redirect(['_name' => 'import:index']);
         }
@@ -101,7 +103,7 @@ class ImportController extends AppController
             8 => __('an extension stopped the file upload'),
         ];
 
-        return Hash::get($errors, $code, __('Unkown upload error'));
+        return (string)Hash::get($errors, (string)$code, __('Unkown upload error'));
     }
 
     /**

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -62,8 +62,8 @@ class ImportController extends AppController
             $importFilter = new $filter($this->apiClient);
 
             // see http://php.net/manual/en/features.file-upload.errors.php
-            $fileError = (int)$this->request->getData('file.error', 4);
-            if ($fileError > 0) {
+            $fileError = (int)$this->request->getData('file.error', UPLOAD_ERR_NO_FILE);
+            if ($fileError > UPLOAD_ERR_OK) {
                 throw new BadRequestException($this->uploadErrorMessage($fileError));
             }
 
@@ -94,13 +94,13 @@ class ImportController extends AppController
     protected function uploadErrorMessage(int $code)
     {
         $errors = [
-            1 => __('File is too big, max allowed size is {0}', ini_get('upload_max_filesize')),
-            2 => __('File is too big, form MAX_FILE_SIZE exceeded'),
-            3 => __('File only partially uploaded'),
-            4 => __('Missing import file'),
-            6 => __('Temporary folder missing'),
-            6 => __('Failed to write file to disk'),
-            8 => __('an extension stopped the file upload'),
+            UPLOAD_ERR_INI_SIZE => __('File is too big, max allowed size is {0}', ini_get('upload_max_filesize')),
+            UPLOAD_ERR_FORM_SIZE => __('File is too big, form MAX_FILE_SIZE exceeded'),
+            UPLOAD_ERR_PARTIAL => __('File only partially uploaded'),
+            UPLOAD_ERR_NO_FILE => __('Missing import file'),
+            UPLOAD_ERR_NO_TMP_DIR => __('Temporary folder missing'),
+            UPLOAD_ERR_CANT_WRITE => __('Failed to write file to disk'),
+            UPLOAD_ERR_EXTENSION => __('An extension stopped the file upload'),
         ];
 
         return (string)Hash::get($errors, (string)$code, __('Unkown upload error'));

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -16,6 +16,7 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Http\Response;
 use Cake\Network\Exception\BadRequestException;
+use Exception;
 
 /**
  * Import controller: upload and load using filters
@@ -51,16 +52,19 @@ class ImportController extends AppController
      */
     public function file() : ?Response
     {
-        // prepare import filter
-        $filter = $this->request->getData('filter');
-        if (empty($filter)) {
-            throw new BadRequestException('Import filter not selected', 500);
-        }
-        $importFilter = new $filter($this->apiClient);
-        // read file
-        $filename = $this->request->getData('file.name');
-        $filepath = $this->request->getData('file.tmp_name');
         try {
+            $filter = $this->request->getData('filter');
+            if (empty($filter)) {
+                throw new BadRequestException(__('Import filter not selected'));
+            }
+            $importFilter = new $filter($this->apiClient);
+
+            $filename = $this->request->getData('file.name');
+            $filepath = $this->request->getData('file.tmp_name');
+            if (empty($filename) || empty($filepath)) {
+                throw new BadRequestException(__('Missing import file'));
+            }
+
             $result = $importFilter->import($filename, $filepath);
             $this->set(compact('result'));
         } catch (Exception $e) {

--- a/tests/TestCase/Controller/ImportControllerTest.php
+++ b/tests/TestCase/Controller/ImportControllerTest.php
@@ -18,7 +18,9 @@ use App\Core\Filter\ImportFilter;
 use App\Core\Result\ImportResult;
 use Cake\Http\ServerRequest;
 use Cake\Network\Exception\BadRequestException;
+use Cake\Network\Exception\InternalErrorException;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 class ImportControllerSample extends ImportController
 {
@@ -28,14 +30,6 @@ class ImportControllerSample extends ImportController
     public function render($view = null, $layout = null)
     {
         // do nothing
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function redirect($url, $status = 302)
-    {
-        return null;
     }
 }
 
@@ -63,7 +57,7 @@ class ImportFilterSampleError extends ImportFilter
      */
     public function import($filename, $filepath, ?array $options = []) : ImportResult
     {
-        throw new \Exception('An expected exception');
+        throw new InternalErrorException('An expected exception');
     }
 }
 
@@ -132,26 +126,43 @@ class ImportControllerTest extends TestCase
     }
 
     /**
-     * Test `file` fail method
+     * Test `file` fail method, missing filter
      *
      * @covers ::file()
      *
      * @return void
      */
-    public function testFileBadRequest() : void
+    public function testFileBadRequestFilter() : void
     {
-        $expected = new BadRequestException('Import filter not selected', 500);
-        $this->expectException(get_class($expected));
-        $this->expectExceptionCode($expected->getCode());
-        $this->expectExceptionMessage($expected->getMessage());
-
         $this->setupController();
         $response = $this->Import->file();
-        static::assertNull($response);
+        static::assertEquals(302, $response->getStatusCode());
+        $flash = $this->Import->request->session()->read('Flash.flash');
+        static::assertEquals('Import filter not selected', Hash::get($flash, '0.message'));
+        static::assertEquals(400, Hash::get($flash, '0.params.code'));
     }
 
     /**
-     * Test `file` fail method
+     * Test `file` fail method, missing files
+     *
+     * @covers ::file()
+     *
+     * @return void
+     */
+    public function testFileBadRequestFile() : void
+    {
+        $this->filename = null;
+        $this->setupController('App\Test\TestCase\Controller\ImportFilterSample');
+
+        $response = $this->Import->file();
+        static::assertEquals(302, $response->getStatusCode());
+        $flash = $this->Import->request->session()->read('Flash.flash');
+        static::assertEquals('Missing import file', Hash::get($flash, '0.message'));
+        static::assertEquals(400, Hash::get($flash, '0.params.code'));
+    }
+
+    /**
+     * Test `file` fail method, internal error
      *
      * @covers ::file()
      *
@@ -159,12 +170,11 @@ class ImportControllerTest extends TestCase
      */
     public function testFileError() : void
     {
-        $expected = new \Exception('An expected exception');
-        $this->expectException(get_class($expected));
-        $this->expectExceptionCode($expected->getCode());
-        $this->expectExceptionMessage($expected->getMessage());
-
         $this->setupController('App\Test\TestCase\Controller\ImportFilterSampleError');
         $response = $this->Import->file();
+        static::assertEquals(302, $response->getStatusCode());
+        $flash = $this->Import->request->session()->read('Flash.flash');
+        static::assertEquals('An expected exception', Hash::get($flash, '0.message'));
+        static::assertEquals(500, Hash::get($flash, '0.params.code'));
     }
 }

--- a/tests/TestCase/Controller/ImportControllerTest.php
+++ b/tests/TestCase/Controller/ImportControllerTest.php
@@ -83,6 +83,13 @@ class ImportControllerTest extends TestCase
     protected $filename = 'test.png';
 
     /**
+     * Test file error
+     *
+     * @var string
+     */
+    protected $fileError = 0;
+
+    /**
      * Setup import controller for test
      *
      * @param string $filter The filter class full path.
@@ -98,6 +105,7 @@ class ImportControllerTest extends TestCase
                 'file' => [
                     'name' => $this->filename,
                     'tmp_name' => sprintf('%s/tests/files/%s', getcwd(), $this->filename),
+                    'error' => $this->fileError,
                 ],
                 'filter' => $filter,
             ],
@@ -146,12 +154,13 @@ class ImportControllerTest extends TestCase
      * Test `file` fail method, missing files
      *
      * @covers ::file()
+     * @covers:: uploadErrorMessage()
      *
      * @return void
      */
     public function testFileBadRequestFile() : void
     {
-        $this->filename = null;
+        $this->fileError = 4;
         $this->setupController('App\Test\TestCase\Controller\ImportFilterSample');
 
         $response = $this->Import->file();


### PR DESCRIPTION
* flash error messages are used for every error type - more consistent, no page change
* more precise upload error messages from error codes http://php.net/manual/en/features.file-upload.errors.php
