### PR TITLE
Setup user `timezone` at login

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -101,6 +101,11 @@ date_default_timezone_set('UTC');
  */
 mb_internal_encoding(Configure::read('App.encoding'));
 
+/**
+ * Set default output timezone, can be overridden by user session timezone
+ */
+Configure::write('I18n.timezone', 'UTC');
+
 /*
  * Set the default locale. This controls how dates, number and currency is
  * formatted and sets the default language to use for translations.

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -75,8 +75,21 @@ class AppController extends Controller
         if ($tokens) {
             $this->apiClient->setupTokens($tokens);
         }
+        $this->setupOutputTimezone();
     }
 
+    /**
+     * Setup output timezone from user session
+     *
+     * @return void
+     */
+    protected function setupOutputTimezone(): void
+    {
+        $timezone = $this->Auth->user('timezone');
+        if ($timezone) {
+            Configure::write('I18n.timezone', $timezone);
+        }
+    }
     /**
      * {@inheritDoc}
      *

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -76,7 +76,7 @@ class LoginController extends AppController
         if (empty($offset)) {
             return 'UTC';
         }
-        $data = explode(' ', $offset);
+        $data = explode(' ', (string)$offset);
         $dst = empty($data[1]) ? 0 : 1;
 
         return timezone_name_from_abbr('', intval($data[0]), $dst);

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -48,10 +48,11 @@ class LoginController extends AppController
                 $reason = $attributes['reason'];
             }
         }
-        if (!empty($user)) {
+        if (!empty($user) && is_array($user)) {
+            // setup timezone from request
+            $user['timezone'] = $this->request->getData('timezone');
             // Successful login. Redirect.
             $this->Auth->setUser($user);
-            // $this->Flash->success(__('Successfully logged in'));
 
             return $this->redirect($this->Auth->redirectUrl());
         }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -50,7 +50,7 @@ class LoginController extends AppController
         }
         if (!empty($user) && is_array($user)) {
             // setup timezone from request
-            $user['timezone'] = $this->request->getData('timezone');
+            $user['timezone'] = $this->userTimezone();
             // Successful login. Redirect.
             $this->Auth->setUser($user);
 
@@ -61,6 +61,25 @@ class LoginController extends AppController
         $this->Flash->error(__($reason));
 
         return null;
+    }
+
+    /**
+     * Retrieve user timezone from request data.
+     *
+     * @return string User timezone
+     */
+    protected function userTimezone()
+    {
+        // 'timezone_offset' must contain UTC offset in seconds
+        // plus Daylight Saving Time DST 0 or 1 like: '3600 1' or '7200 0'
+        $offset = $this->request->getData('timezone_offset');
+        if (empty($offset)) {
+            return 'UTC';
+        }
+        $data = explode(' ', $offset);
+        $dst = empty($data[1]) ? 0 : 1;
+
+        return timezone_name_from_abbr('', intval($data[0]), $dst);
     }
 
     /**

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -68,7 +68,7 @@ class LoginController extends AppController
      *
      * @return string User timezone
      */
-    protected function userTimezone()
+    protected function userTimezone() : string
     {
         // 'timezone_offset' must contain UTC offset in seconds
         // plus Daylight Saving Time DST 0 or 1 like: '3600 1' or '7200 0'

--- a/src/Template/Pages/Login/login.twig
+++ b/src/Template/Pages/Login/login.twig
@@ -24,9 +24,25 @@
     })|raw }}
     <label>{{ __('Password') }}</label>
 
-    {{ Form.control('timezone', {
+{# JS code:
+
+Date.prototype.stdTimezoneOffset = function() {
+  var jan = new Date(this.getFullYear(), 0, 1);
+  var jul = new Date(this.getFullYear(), 6, 1);
+  return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+}
+
+Date.prototype.dst = function() {
+  return this.getTimezoneOffset() < this.stdTimezoneOffset();
+}
+
+$('#timezone-offset').value = (-60) * (new Date().getTimezoneOffset()) + ' ' + (new Date().dst() ? '1' : '0')
+
+[results like: '3600 1' or '7200 0']
+#}
+    {{ Form.control('timezone_offset', {
         'label': false,
-        'value': 'UTC',
+        'value': '0',
         'style': 'display: none'
     })|raw }}
 

--- a/src/Template/Pages/Login/login.twig
+++ b/src/Template/Pages/Login/login.twig
@@ -24,22 +24,23 @@
     })|raw }}
     <label>{{ __('Password') }}</label>
 
-{# JS code:
+    <script>
+        Date.prototype.stdTimezoneOffset = function() {
+            var jan = new Date(this.getFullYear(), 0, 1);
+            var jul = new Date(this.getFullYear(), 6, 1);
+            return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+        }
 
-Date.prototype.stdTimezoneOffset = function() {
-  var jan = new Date(this.getFullYear(), 0, 1);
-  var jul = new Date(this.getFullYear(), 6, 1);
-  return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
-}
+        Date.prototype.dst = function() {
+            return this.getTimezoneOffset() < this.stdTimezoneOffset();
+        }
 
-Date.prototype.dst = function() {
-  return this.getTimezoneOffset() < this.stdTimezoneOffset();
-}
+        document.addEventListener("DOMContentLoaded", function() {
+            var tz = (-60) * (new Date().getTimezoneOffset()) + ' ' + (new Date().dst() ? '1' : '0');
+            document.getElementById('timezone-offset').value = tz;
+        });
+    </script>
 
-$('#timezone-offset').value = (-60) * (new Date().getTimezoneOffset()) + ' ' + (new Date().dst() ? '1' : '0')
-
-[results like: '3600 1' or '7200 0']
-#}
     {{ Form.control('timezone_offset', {
         'label': false,
         'value': '0',

--- a/src/Template/Pages/Login/login.twig
+++ b/src/Template/Pages/Login/login.twig
@@ -24,6 +24,12 @@
     })|raw }}
     <label>{{ __('Password') }}</label>
 
+    {{ Form.control('timezone', {
+        'label': false,
+        'value': 'UTC',
+        'style': 'display: none'
+    })|raw }}
+
     {{ Form.submit(__('Sign in'))|raw }}
 
     {{ Form.end()|raw }}

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -46,7 +46,7 @@ class AppView extends TwigView
         $this->loadHelper('Text');
         $this->loadHelper('BEdita/WebTools.Thumb');
         $this->loadHelper('Url');
-        $this->loadHelper('Time');
+        $this->loadHelper('Time', ['outputTimezone' => Configure::read('I18n.timezone', 'UTC')]);
     }
 
     /**

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -63,9 +63,10 @@ class LoginControllerTest extends TestCase
     }
 
     /**
-     * Test `login` method
+     * Test `login` method, no user timezone set
      *
      * @covers ::login()
+     * @covers ::userTimezone()
      *
      * @return void
      */
@@ -81,6 +82,31 @@ class LoginControllerTest extends TestCase
         $response = $this->Login->login();
         static::assertEquals(302, $response->getStatusCode());
         static::assertEquals('/', $response->getHeaderLine('Location'));
+    }
+
+    /**
+     * Test `userTimezone` method
+     *
+     * @covers ::userTimezone()
+     *
+     * @return void
+     */
+    public function testLoginTimezone()
+    {
+        $this->setupController([
+            'post' => [
+                'username' => env('BEDITA_ADMIN_USR'),
+                'password' => env('BEDITA_ADMIN_PWD'),
+                'timezone_offset' => '7200 0'
+            ]
+        ]);
+
+        $response = $this->Login->login();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('/', $response->getHeaderLine('Location'));
+
+        $tz = $this->Login->Auth->user('timezone');
+        static::assertNotEquals('UTC', $tz);
     }
 
     /**


### PR DESCRIPTION
User timezone is saved in session upon login. This is needed to complete #163 
It must be calculated via Javascript since there's no way to know it from HTTP. 
This timezone is used only to display date times from PHP, internally only `UTC` is (or should be) used.

In the JS snipped at login also DST (daylight saving time) is considered.

We do not track user timezone changes during session... but we can live with that I think :wink: 