### PR TITLE
Project `lang` select #169

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -113,8 +113,21 @@ return [
             'prefix' => 'schema_types_',
             'path' => CACHE . 'schema_types/',
             'serialize' => true,
-            'duration' => '+1 year',
+            'duration' => '+1 day',
             'url' => env('CACHE_SCHEMATYPES_URL', null),
+        ],
+
+        /**
+         * Configure the cache used for project configuration caching.
+         * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
+         */
+        '_project_config_' => [
+            'className' => 'File',
+            'prefix' => '_project_config_',
+            'path' => CACHE . 'project_config/',
+            'serialize' => true,
+            'duration' => '+1 day',
+            'url' => env('CACHE_PROJECTCONFIG_URL', null),
         ],
 
         /**

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -87,6 +87,7 @@ if (Configure::read('debug')) {
     Configure::write('Cache._cake_model_.duration', '+2 minutes');
     Configure::write('Cache._cake_core_.duration', '+2 minutes');
     Configure::write('Cache._schema_types_.duration', '+2 minutes');
+    Configure::write('Cache._project_config_.duration', '+2 minutes');
 }
 
 /*

--- a/src/Controller/Component/ProjectConfigurationComponent.php
+++ b/src/Controller/Component/ProjectConfigurationComponent.php
@@ -21,7 +21,7 @@ use Cake\Utility\Hash;
 use Psr\Log\LogLevel;
 
 /**
- * Read and update project configuration from `/config`.
+ * Read project configuration from `/config`.
  */
 class ProjectConfigurationComponent extends Component
 {
@@ -35,7 +35,7 @@ class ProjectConfigurationComponent extends Component
     /**
      * Read project configuration from API using cache ad write it in `Project` config key.
      *
-     * @return array JSON Schema.
+     * @return array Project configuration in `key => value` format.
      */
     public function read() : array
     {

--- a/src/Controller/Component/ProjectConfigurationComponent.php
+++ b/src/Controller/Component/ProjectConfigurationComponent.php
@@ -73,7 +73,7 @@ class ProjectConfigurationComponent extends Component
     }
 
     /**
-     * Fetch Peoject configuration via API and manipulate response array.
+     * Fetch Project configuration via API and manipulate response array.
      *
      * @return array Configuration array with a config key => data structure.
      */

--- a/src/Controller/Component/ProjectConfigurationComponent.php
+++ b/src/Controller/Component/ProjectConfigurationComponent.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Controller\Component;
+
+use BEdita\SDK\BEditaClientException;
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Cache\Cache;
+use Cake\Controller\Component;
+use Cake\Core\Configure;
+use Cake\Utility\Hash;
+use Psr\Log\LogLevel;
+
+/**
+ * Read and update project configuration from `/config`.
+ */
+class ProjectConfigurationComponent extends Component
+{
+    /**
+     * Cache config name for project configuration.
+     *
+     * @var string
+     */
+    public const CACHE_CONFIG = '_project_config_';
+
+    /**
+     * Read project configuration from API using cache ad write it in `Project` config key.
+     *
+     * @return array JSON Schema.
+     */
+    public function read() : array
+    {
+        $config = Configure::read('Project');
+        if (!empty($config)) {
+            return $config;
+        }
+        try {
+            $config = Cache::remember(
+                $this->cacheKey(),
+                function () {
+                    return $this->fetchConfig();
+                },
+                self::CACHE_CONFIG
+            );
+            Configure::write('Project', $config);
+        } catch (BEditaClientException $e) {
+            // Something bad happened
+            $this->log($e, LogLevel::ERROR);
+
+            return [];
+        }
+
+        return $config;
+    }
+
+    /**
+     * Configuration key name for project config cache.
+     *
+     * @return string
+     */
+    protected function cacheKey() : string
+    {
+        return md5(ApiClientProvider::getApiClient()->getApiBaseUrl());
+    }
+
+    /**
+     * Fetch Peoject configuration via API and manipulate response array.
+     *
+     * @return array Configuration array with a config key => data structure.
+     */
+    protected function fetchConfig()
+    {
+        $response = ApiClientProvider::getApiClient()->get('config', ['page_size' => 100]);
+
+        $config = Hash::combine($response, 'data.{n}.id', 'data.{n}.attributes.content');
+        array_walk(
+            $config,
+            function (&$value, $key) {
+                $value = json_decode($value, true);
+            }
+        );
+
+        return $config;
+    }
+}

--- a/src/Controller/Component/ProjectConfigurationComponent.php
+++ b/src/Controller/Component/ProjectConfigurationComponent.php
@@ -77,7 +77,7 @@ class ProjectConfigurationComponent extends Component
      *
      * @return array Configuration array with a config key => data structure.
      */
-    protected function fetchConfig()
+    protected function fetchConfig() : array
     {
         $response = ApiClientProvider::getApiClient()->get('config', ['page_size' => 100]);
 

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -40,6 +40,7 @@ class ModulesController extends AppController
         parent::initialize();
 
         $this->loadComponent('Properties');
+        $this->loadComponent('ProjectConfiguration');
 
         if (!empty($this->request)) {
             $this->objectType = $this->request->getParam('object_type');
@@ -158,6 +159,7 @@ class ModulesController extends AppController
 
             return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType]);
         }
+        $this->ProjectConfiguration->read();
 
         $revision = Hash::get($response, 'meta.schema.' . $this->objectType . '.revision', null);
         $schema = $this->Schema->getSchema($this->objectType, $revision);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -21,6 +21,7 @@ use Psr\Log\LogLevel;
 /**
  * Modules controller: list, add, edit, remove objects
  *
+ * @property \App\Controller\Component\ProjectConfigurationComponent $ProjectConfiguration
  * @property \App\Controller\Component\PropertiesComponent $Properties
  */
 class ModulesController extends AppController

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -103,10 +103,7 @@ class SchemaHelper extends Helper
                     $options[] = ['value' => $key, 'text' => __($description)];
                 }
 
-                return [
-                    'type' => 'select',
-                    'options' => $options,
-                ];
+                return ['type' => 'select'] + compact('options');
 
             case 'status':
                 return [

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -13,6 +13,7 @@
 
 namespace App\View\Helper;
 
+use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
@@ -90,6 +91,23 @@ class SchemaHelper extends Helper
     protected function customControlOptions($name) : array
     {
         switch ($name) {
+            case 'lang':
+                $languages = Configure::read('Project.I18n.languages');
+                if (empty($languages)) {
+                    return [
+                        'type' => 'text',
+                    ];
+                }
+                $options = [];
+                foreach ($languages as $key => $description) {
+                    $options[] = ['value' => $key, 'text' => __($description)];
+                }
+
+                return [
+                    'type' => 'select',
+                    'options' => $options,
+                ];
+
             case 'status':
                 return [
                     'type' => 'radio',

--- a/tests/TestCase/Controller/Component/ProjectConfigurationComponentTest.php
+++ b/tests/TestCase/Controller/Component/ProjectConfigurationComponentTest.php
@@ -1,0 +1,143 @@
+<?php
+namespace App\Test\TestCase\Controller\Component;
+
+use App\Controller\Component\ProjectConfigurationComponent;
+use BEdita\SDK\BEditaClient;
+use BEdita\SDK\BEditaClientException;
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Cache\Cache;
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Controller\Component\ProjectConfigurationComponent} Test Case
+ *
+ * @coversDefaultClass \App\Controller\Component\ProjectConfigurationComponent
+ */
+class ProjectConfigurationComponentTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \App\Controller\Component\ProjectConfigurationComponent
+     */
+    public $ProjectConfiguration;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $controller = new Controller();
+        $registry = $controller->components();
+        $registry->load('Auth');
+        $this->ProjectConfiguration = $registry->load(ProjectConfigurationComponent::class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown() : void
+    {
+        unset($this->ProjectConfiguration);
+
+        // reset client, force new client creation
+        ApiClientProvider::setApiClient(null);
+        parent::tearDown();
+    }
+
+    /**
+     * Data provider for `testRead` test case.
+     *
+     * @return array
+     */
+    public function readProvider() : array
+    {
+        return [
+            'simple conf' => [
+                [
+                    'Simple' => ['a' => 2],
+                ],
+                [
+                    'id' => 'Simple',
+                    'type' => 'config',
+                    'attributes' => [
+                        'content' => '{"a":2}'
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `read()` method.
+     *
+     * @param array $expected Expected result.
+     * @param array $config Response from `/config` endpoint.
+     * @return void
+     *
+     * @dataProvider readProvider()
+     * @covers ::read()
+     * @covers ::cacheKey()
+     * @covers ::fetchConfig()
+     */
+    public function testRead($expected, $config) : void
+    {
+        Configure::write('Project', null);
+        // Setup mock API client.
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('get')
+            ->with('config')
+            ->willReturn([
+                'data' => [$config],
+            ]);
+        ApiClientProvider::setApiClient($apiClient);
+
+        $project = $this->ProjectConfiguration->read();
+        static::assertSame($expected, $project);
+        static::assertSame($expected, Configure::read('Project'));
+    }
+
+    /**
+     * Test `read()` method with configured data
+     *
+     * @covers ::read()
+     * @return void
+     */
+    public function testReadFromConf() : void
+    {
+        $data = ['Conf' => true];
+        Configure::write('Project', $data);
+        $project = $this->ProjectConfiguration->read();
+        static::assertSame($data, $project);
+    }
+
+    /**
+     * Test `read()` method with API Error
+     *
+     * @covers ::read()
+     * @return void
+     */
+    public function testReadError() : void
+    {
+        Configure::write('Project', null);
+        Cache::clear(false, ProjectConfigurationComponent::CACHE_CONFIG);
+        // Setup mock API client.
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('get')
+            ->with('config')
+            ->willThrowException(new BEditaClientException('Test'));
+
+        ApiClientProvider::setApiClient($apiClient);
+
+        $project = $this->ProjectConfiguration->read();
+        static::assertSame([], $project);
+    }
+}

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -14,6 +14,7 @@
 namespace App\Test\TestCase\View\Helper;
 
 use App\View\Helper\SchemaHelper;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
 
@@ -457,6 +458,42 @@ class SchemaHelperTest extends TestCase
     {
         $actual = $this->Schema->controlOptions($name, $value, $schema);
 
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Test `lang` property
+     *
+     * @return void
+     */
+    public function testLang()
+    {
+        Configure::write('Project.I18n', null);
+        $actual = $this->Schema->controlOptions('lang', null, []);
+        static::assertSame(['type' => 'text'], $actual);
+
+        $i18n = [
+            'languages' => [
+                'en' => 'English',
+                'de' => 'German',
+            ]
+            ];
+        Configure::write('Project.I18n', $i18n);
+        $actual = $this->Schema->controlOptions('lang', null, []);
+
+        $expected = [
+            'type' => 'select',
+            'options' => [
+                [
+                    'value' => 'en',
+                    'text' => 'English',
+                ],
+                [
+                    'value' => 'de',
+                    'text' => 'German',
+                ],
+            ],
+        ];
         static::assertSame($expected, $actual);
     }
 }

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -476,8 +476,8 @@ class SchemaHelperTest extends TestCase
             'languages' => [
                 'en' => 'English',
                 'de' => 'German',
-            ]
-            ];
+            ],
+        ];
         Configure::write('Project.I18n', $i18n);
         $actual = $this->Schema->controlOptions('lang', null, []);
 


### PR DESCRIPTION
This PR fixes #169 

* a new `ProjectConfigurationComponent` has been introduced to handle project configuration from API via `/config`
* configuration is saved in a ner `_project_config_` cache, multiple projects are supported; configuration store in `Project` app configuration key; this way `I18n` configuration from API will be available via `Configure::read('Project.I18n')`
* `SchemaHelper` was changed in order to use a `select` if a list of languages is defined `'Project.I18n.languages'` config otherwise a normal text input is used

`SchemaHelper` needs an urgent refactor (in a new issue)
