### PR TITLE
Chore/fix appcontroller test

### DIFF
--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -184,7 +184,9 @@ class AppControllerTest extends TestCase
         $event = $this->AppController->dispatchEvent('Controller.beforeRender');
 
         static::assertArrayHasKey('user', $this->AppController->viewVars);
-        static::assertEquals($user, $this->AppController->viewVars['user']);
+        static::assertArrayHasKey('tokens', $this->AppController->viewVars['user']);
+        static::assertArrayHasKey('jwt', $this->AppController->viewVars['user']['tokens']);
+        static::assertArrayHasKey('renew', $this->AppController->viewVars['user']['tokens']);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a unit test error it may randomly appear.
A refresh token may happen in current test method, assert may then change.
Since there are other test methods to verify tokens we can safely check array structure only. 