### PR TITLE
Fix/other properties

### DIFF
--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -45,10 +45,11 @@ class PropertiesComponent extends Component
                 'extra',
             ],
             // remaining attributes
+            // items listed here only used for ordering, not listed if present in other groups
             'other' => [
                 'body',
                 'lang',
-                // other properties
+                // remaining attributes
             ],
         ],
         // index properties list
@@ -118,6 +119,7 @@ class PropertiesComponent extends Component
             $used = array_merge($used, $list);
         }
         // add remaining properties to 'other' group
+        $properties['other'] = array_diff_key($properties['other'], array_flip($used));
         $properties['other'] += array_diff_key($attributes, array_flip($used));
 
         return $properties;

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -2,6 +2,8 @@
 {% set otherProperties = Array.removeKeys(properties, ['core', '_keep', 'publish', 'advanced']) %}
 {% for group, props in otherProperties %}
 
+{% if props %}
+
 <property-view inline-template :tab-open="tabsOpen">
 
     <section class="fieldset order-{{ cssOrder }}" id="{{ group|underscore }}_properties" :class="isOpen? '' : 'closed'">
@@ -27,5 +29,7 @@
     </section>
 
 </property-view>
+
+{% endif %}
 
 {% endfor %}

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -267,6 +267,36 @@ class PropertiesComponentTest extends TestCase
                     ],
                 ]
             ],
+            'other body' => [
+                [
+                    'core' => [
+                        'title' => 'Example',
+                        'body' => 'some text',
+                        'lang' => 'en'
+                    ],
+                    'publish' => [
+                    ],
+                    'advanced' => [
+                    ],
+                    'other' => [
+                    ],
+                ],
+                [
+                    'attributes' => [
+                        'title' => 'Example',
+                        'body' => 'some text',
+                        'lang' => 'en'
+                    ],
+                ],
+                'foos',
+                [
+                    'core' => [
+                        'title',
+                        'body',
+                        'lang',
+                    ],
+                ]
+            ],
         ];
     }
 
@@ -292,7 +322,12 @@ class PropertiesComponentTest extends TestCase
         $this->createComponent();
 
         $result = $this->Properties->viewGroups($object, $type);
+        ksort($expected);
+        ksort($result);
 
-        static::assertSame(sort($expected), sort($result));
+        static::assertEquals($expected, $result);
+        foreach ($expected as $k => $v) {
+            static::assertEquals($v, $result[$k]);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a bug occurring when `other` group properties may contain duplicate attributes present in other group properties.

Bonus: don't display a group if empty
