### PR TITLE
feat: new yarn start command to run php server with webpack proxy on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,6 @@ export BEDITA_API="{bedita-4-url}"
 export BEDITA_API_KEY="{bedita4-api-key}"
 ```
 
-You are then ready to use the webapp by simply run builtin webserver like this
-
-```bash
-bin/cake server
-```
-
-And then point your browser to `http://localhost:8765/`
-
-Or you can configure your preferred web server like Nginx/Apache and point to `webroot/` as vhost document root.
-
 ## Docker
 
 ### Pull official image
@@ -81,6 +71,30 @@ Replace `bedita/web:latest` with `be4web-local` (or other chosen name) to lanch 
 ### Run dev with webpack
 
 ## Development
+
+With this command you will launch a cake server and a webpack proxy server all with one command
+
+```bash
+yarn start
+```
+
+## Custom Dev Environment
+
+If you feel you want to customize ports, vhosts or you have your own php server then you can use these commands
+
+### Cake side App
+
+If you don't have a php enabled web server (apache...) you can use cake builtin server
+
+```bash
+bin/cake server
+```
+
+And then point your browser to `http://localhost:8765/`
+
+Or you can configure your preferred web server like Nginx/Apache and point to `webroot/` as vhost document root.
+
+### Vue side App
 
 ```bash
 yarn run develop --proxy localhost:1234

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     },
     "homepage": "https://github.com/bedita/web#README",
     "scripts": {
+        "start": "(bin/cake server -H 0.0.0.0 -p 4545 & yarn develop --proxy 0.0.0.0:4545)",
         "build": "webpack --mode production",
         "bundle-report": "webpack --mode production --report",
         "develop": "webpack --mode development",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,6 +75,9 @@ if (devMode || forceReport) {
 if (devMode) {
     webpackPlugins.push(
         new BrowserSyncPlugin({
+            index: '',
+            host: ENVIRONMENT.host,
+            port: ENVIRONMENT.port,
             proxy: {
                 target: process.argv.host || ENVIRONMENT.proxy,
                 proxyReq: [
@@ -83,14 +86,12 @@ if (devMode) {
                         proxyReq.setHeader('Access-Control-Allow-Headers', 'content-type, origin, x-api-key, x-requested-with, authorization');
                         proxyReq.setHeader('Access-Control-Allow-Methods', 'PUT, GET, POST, PATCH, DELETE, OPTIONS');
                     }
-                ]
+                ],
             },
             cors: true,
             notify: true,
             open: false,
             reloadOnRestart: true,
-            host: ENVIRONMENT.host,
-            port: ENVIRONMENT.port,
         })
     );
 


### PR DESCRIPTION
```
yarn start
```
will launch:
- bin/cake server on port 4545
- webpack web server proxying port 4545

the two separate command are grouped therefore killing the main process will kill them all
