### PR TITLE
Fix `other` properties display

### DIFF
--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -116,7 +116,9 @@ class PropertiesComponent extends Component
                 }
             }
             $properties[$group] = $p;
-            $used = array_merge($used, $list);
+            if ($group !== 'other') {
+                $used = array_merge($used, $list);
+            }
         }
         // add remaining properties to 'other' group
         $properties['other'] = array_diff_key($properties['other'], array_flip($used));

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -297,6 +297,30 @@ class PropertiesComponentTest extends TestCase
                     ],
                 ]
             ],
+            'other defaults' => [
+                [
+                    'core' => [
+                        'title' => 'Example',
+                    ],
+                    'publish' => [
+                    ],
+                    'advanced' => [
+                    ],
+                    'other' => [
+                        'body' => 'some text',
+                        'lang' => 'en'
+                    ],
+                ],
+                [
+                    'attributes' => [
+                        'title' => 'Example',
+                        'body' => 'some text',
+                        'lang' => 'en'
+                    ],
+                ],
+                'foos'
+            ],
+
         ];
     }
 


### PR DESCRIPTION
This PR fixes a bug in `other` properties groups, as items listed in `other` default or custom configuration were not displayed.

A test case has been added with this case.
