### PR TITLE
fix: script include order (plugins first)

### DIFF
--- a/src/Template/Layout/default.twig
+++ b/src/Template/Layout/default.twig
@@ -114,9 +114,9 @@ BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
     {# vendors.bundle it's only generated when vendors are imported statically, uncomment if you do so #}
     {# {{ Html.script('vendors.bundle')|raw }} #}
 
-    {{ Link.jsBundle([ 'manifest', 'vendors', 'app' ])|raw }}
-
     {{ Link.pluginsJsBundle()|raw }}
+
+    {{ Link.jsBundle([ 'manifest', 'vendors', 'app' ])|raw }}
 
     {# {{ Html.script('app.bundle')|raw }} #}
 


### PR DESCRIPTION
This fixes a js plugin registration issue.
Solution: `default.twig` template include first `pluginsJsBundle` then other js bundles.